### PR TITLE
Transition to bismark v0.16.1 and FastQC v0.11.5

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -15,3 +15,13 @@ This file gives the current version of software used in the pipeline as of March
 * trim_galore v0.4.1
 	* cutadapt v1.7.1
 	* FastQC v0.10.1
+
+The following R command will install the required R packages (assuming fresh R install):
+
+```{r}
+install.packages(c('readr','optparse','ggplot2','dplyr','devtools'), repos='http://cran.rstudio.com')
+source("http://bioconductor.org/biocLite.R")
+biocLite(c("BiocStyle","GenomeInfoDb","IRanges","GenomicRanges"))
+devtools::install_github('sartorlab/methylSig')
+devtools::install_github('rcavalcante/annotatr')
+```

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,17 +4,17 @@ This file gives the current version of software used in the pipeline as of March
 
 * bedtools v2.25.0
 * bedops v2.4.14
-* bismark v0.14.4
-* bowtie2 v2.2.1
+* bismark v0.16.1
+* bowtie2 v2.2.4
 * macs2 v2.1.0.20140616
 * PePr v1.0.9
-* R v3.2.0
+* R v3.2.5
 	* annotatr v0.7.0
-	* methylSig v0.4.1
-* samtools v0.1.18
+	* methylSig v0.4.2
+* samtools v0.1.19
 * trim_galore v0.4.1
-	* cutadapt v1.7.1
-	* FastQC v0.10.1
+* cutadapt v1.9.1
+* FastQC v0.11.5
 
 The following R command will install the required R packages (assuming fresh R install):
 

--- a/scripts/annotatr_bisulfite.R
+++ b/scripts/annotatr_bisulfite.R
@@ -73,7 +73,8 @@ if(genome %in% c('hg19','hg38','mm9','mm10')) {
 			'knownGenes_5UTRs',
 			'knownGenes_exons',
 			'knownGenes_introns',
-			'knownGenes_3UTRs'), sep='_')
+			'knownGenes_3UTRs',
+			'knownGenes_intergenic'), sep='_')
 		a_all_order = c(
 			a_cpg_order,
 			a_gene_order)
@@ -89,7 +90,8 @@ if(genome %in% c('hg19','hg38','mm9','mm10')) {
 			'knownGenes_5UTRs',
 			'knownGenes_exons',
 			'knownGenes_introns',
-			'knownGenes_3UTRs'), sep='_')
+			'knownGenes_3UTRs',
+			'knownGenes_intergenic'), sep='_')
 		a_all_order = c(
 			a_cpg_order,
 			a_gene_order)

--- a/scripts/annotatr_bisulfite.R
+++ b/scripts/annotatr_bisulfite.R
@@ -149,7 +149,6 @@ if(suffix == 'bismark') {
 		bin_width = 10,
 		plot_title = sprintf('%s coverage over annotations', sample),
 		x_label = 'Coverage')
-	plot_coverage = plot_coverage + scale_x_log10()
 	ggplot2::ggsave(filename = coverage_png, plot = plot_coverage, width = 8, height = 8)
 
 	percmeth_png = sprintf('summary/figures/%s_%s_percmeth.png', sample, suffix)

--- a/scripts/annotatr_bisulfite.R
+++ b/scripts/annotatr_bisulfite.R
@@ -149,6 +149,7 @@ if(suffix == 'bismark') {
 		bin_width = 10,
 		plot_title = sprintf('%s coverage over annotations', sample),
 		x_label = 'Coverage')
+	plot_coverage = plot_coverage + scale_x_log10()
 	ggplot2::ggsave(filename = coverage_png, plot = plot_coverage, width = 8, height = 8)
 
 	percmeth_png = sprintf('summary/figures/%s_%s_percmeth.png', sample, suffix)

--- a/scripts/annotatr_bisulfite.R
+++ b/scripts/annotatr_bisulfite.R
@@ -47,7 +47,8 @@ if(suffix == 'methylSig') {
 if(genome %in% c('hg19','hg38','mm9','mm10')) {
 	a = c(
 		sprintf('%s_cpgs', genome),
-		sprintf('%s_basicgenes', genome))
+		sprintf('%s_basicgenes', genome),
+		sprintf('%s_knownGenes_intergenic', genome))
 } else {
 	# TODO: Add support for insertion of custom annotation path via command line
 	stop('Only hg19, hg38, mm9, and mm10 annotations are supported for this part of mint at the moment.')

--- a/scripts/annotatr_bisulfite.R
+++ b/scripts/annotatr_bisulfite.R
@@ -149,6 +149,7 @@ if(suffix == 'bismark') {
 		bin_width = 10,
 		plot_title = sprintf('%s coverage over annotations', sample),
 		x_label = 'Coverage')
+	plot_coverage = plot_coverage + xlim(0,500)
 	ggplot2::ggsave(filename = coverage_png, plot = plot_coverage, width = 8, height = 8)
 
 	percmeth_png = sprintf('summary/figures/%s_%s_percmeth.png', sample, suffix)

--- a/scripts/annotatr_bisulfite.R
+++ b/scripts/annotatr_bisulfite.R
@@ -11,8 +11,8 @@ opt = parse_args(OptionParser(option_list=option_list))
 
 file = opt$file
 genome = opt$genome
-if(grepl('_trimmed.fq.gz_bismark_bt2.CpG_report_for_annotatr.txt', file)) {
-	sample = gsub('_trimmed.fq.gz_bismark_bt2.CpG_report_for_annotatr.txt','', basename(file))
+if(grepl('_trimmed_bismark_bt2.CpG_report_for_annotatr.txt', file)) {
+	sample = gsub('_trimmed_bismark_bt2.CpG_report_for_annotatr.txt','', basename(file))
 	suffix = 'bismark'
 } else if (grepl('_methylSig_for_annotatr.txt', file)) {
 	sample = gsub('_methylSig_for_annotatr.txt','', basename(file))

--- a/scripts/annotatr_classification.R
+++ b/scripts/annotatr_classification.R
@@ -72,7 +72,8 @@ if(genome %in% c('hg19','hg38','mm9','mm10')) {
 			'knownGenes_5UTRs',
 			'knownGenes_exons',
 			'knownGenes_introns',
-			'knownGenes_3UTRs'), sep='_')
+			'knownGenes_3UTRs',
+			'knownGenes_intergenic'), sep='_')
 		a_all_order = c(
 			a_cpg_order,
 			a_gene_order)
@@ -88,7 +89,8 @@ if(genome %in% c('hg19','hg38','mm9','mm10')) {
 			'knownGenes_5UTRs',
 			'knownGenes_exons',
 			'knownGenes_introns',
-			'knownGenes_3UTRs'), sep='_')
+			'knownGenes_3UTRs',
+			'knownGenes_intergenic'), sep='_')
 		a_all_order = c(
 			a_cpg_order,
 			a_gene_order)

--- a/scripts/annotatr_classification.R
+++ b/scripts/annotatr_classification.R
@@ -45,8 +45,10 @@ r = r[r$name != 'unclassifiable']
 # Pick annotations
 if(genome %in% c('hg19','hg38','mm9','mm10')) {
 	a = c(
-		sprintf('%s_cpgs', genome),
-		sprintf('%s_basicgenes', genome))
+		a = c(
+			sprintf('%s_cpgs', genome),
+			sprintf('%s_basicgenes', genome),
+			sprintf('%s_knownGenes_intergenic', genome))
 } else {
 	# TODO: Add support for insertion of custom annotation path via command line
 	stop('Only hg19, hg38, mm9, and mm10 annotations are supported for this part of mint at the moment.')

--- a/scripts/annotatr_classification.R
+++ b/scripts/annotatr_classification.R
@@ -45,10 +45,9 @@ r = r[r$name != 'unclassifiable']
 # Pick annotations
 if(genome %in% c('hg19','hg38','mm9','mm10')) {
 	a = c(
-		a = c(
-			sprintf('%s_cpgs', genome),
-			sprintf('%s_basicgenes', genome),
-			sprintf('%s_knownGenes_intergenic', genome))
+		sprintf('%s_cpgs', genome),
+		sprintf('%s_basicgenes', genome),
+		sprintf('%s_knownGenes_intergenic', genome))
 } else {
 	# TODO: Add support for insertion of custom annotation path via command line
 	stop('Only hg19, hg38, mm9, and mm10 annotations are supported for this part of mint at the moment.')

--- a/scripts/classify_prepare_bisulfite_sample.awk
+++ b/scripts/classify_prepare_bisulfite_sample.awk
@@ -5,19 +5,19 @@ BEGIN {OFS="\t"}
 
 	if ( ($4 + $5 >= 5) && ($4 / ($4 + $5) >= 0.5) ) {
 		### count >= 5 and meth >= 50%
-		sub(/_trimmed\.fq\.gz_bismark_bt2\.CpG_report\.txt/, "_highmeth.txt", outFile)
+		sub(/_trimmed_bismark_bt2\.CpG_report\.txt/, "_highmeth.txt", outFile)
 		print $1, $2 - 1, $2 > outFile
 	} else if ( ($4 + $5 >= 5) && ($4 / ($4 + $5) > 0.05) && ($4 / ($4 + $5) < 0.5) ) {
 		### count >= 5 and 5% < meth < 50%
-		sub(/_trimmed\.fq\.gz_bismark_bt2\.CpG_report\.txt/, "_lowmeth.txt", outFile)
+		sub(/_trimmed_bismark_bt2\.CpG_report\.txt/, "_lowmeth.txt", outFile)
 		print $1, $2 - 1, $2 > outFile
 	} else if ( ($4 + $5 >= 5) && ($4 / ($4 + $5) <= 0.05) ) {
 		### count >= 5 and meth < 5%
-		sub(/_trimmed\.fq\.gz_bismark_bt2\.CpG_report\.txt/, "_nometh_signal.txt", outFile)
+		sub(/_trimmed_bismark_bt2\.CpG_report\.txt/, "_nometh_signal.txt", outFile)
 		print $1, $2 - 1, $2 > outFile
 	} else {
 		### count <= 4
-		sub(/_trimmed\.fq\.gz_bismark_bt2\.CpG_report\.txt/, "_nometh_nosignal.txt", outFile)
+		sub(/_trimmed_bismark_bt2\.CpG_report\.txt/, "_nometh_nosignal.txt", outFile)
 		print $1, $2 - 1, $2 > outFile
 	}
 }

--- a/scripts/classify_simple.R
+++ b/scripts/classify_simple.R
@@ -105,8 +105,7 @@ if(platform == 'pulldown') {
 
 } else if (platform == 'bisulfite') {
 
-	peaks$code = apply(peaks, 1, function(r) {
-		pm = as.numeric(r['perc_meth'])
+	peaks$code = sapply(peaks$perc_meth, function(pm) {
 		if(pm < 5) {
 			return(1)
 		} else if (pm < 33 && pm >= 5) {
@@ -116,7 +115,7 @@ if(platform == 'pulldown') {
 		} else if (pm >= 66) {
 			return(4)
 		}
-	})
+	}, USE.NAMES = FALSE)
 
 }
 

--- a/scripts/classify_simple.R
+++ b/scripts/classify_simple.R
@@ -106,13 +106,14 @@ if(platform == 'pulldown') {
 } else if (platform == 'bisulfite') {
 
 	peaks$code = apply(peaks, 1, function(r) {
-		if(r['perc_meth'] < 5) {
+		pm = as.numeric(r['perc_meth'])
+		if(pm < 5) {
 			return(1)
-		} else if (r['perc_meth'] < 33 && r['perc_meth'] >= 5) {
+		} else if (pm < 33 && pm >= 5) {
 			return(2)
-		} else if (r['perc_meth'] >= 33 && r['perc_meth'] < 66) {
+		} else if (pm >= 33 && pm < 66) {
 			return(3)
-		} else if (r['perc_meth'] >= 66) {
+		} else if (pm >= 66) {
 			return(4)
 		}
 	})

--- a/scripts/sub_init_bis_align.R
+++ b/scripts/sub_init_bis_align.R
@@ -10,14 +10,14 @@ BISULFITE_ALIGN_PREFIXES := %s', paste(bisulfite_samples$fullHumanID, collapse='
 
 make_var_bis_align = 'BISULFITE_ALIGN_PREREQS := 	$(patsubst %,$(DIR_TRACK)/%_simple_classification.bb,$(BISULFITE_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_CLASS_SIMPLE)/%_simple_classification.bed,$(BISULFITE_ALIGN_PREFIXES)) \\
-					$(patsubst %,$(DIR_TRACK)/%_trimmed.fq.gz_bismark_bt2.bw,$(BISULFITE_ALIGN_PREFIXES)) \\
+					$(patsubst %,$(DIR_TRACK)/%_trimmed_bismark_bt2.bw,$(BISULFITE_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_SUM_FIGURES)/%_bismark_counts.png,$(BISULFITE_ALIGN_PREFIXES))\\
 					$(patsubst %,$(DIR_SUM_FIGURES)/%_simple_class_counts.png,$(BISULFITE_ALIGN_PREFIXES))\\
-					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed.fq.gz_bismark_bt2.CpG_report_for_methylSig.txt,$(BISULFITE_ALIGN_PREFIXES)) \\
-					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed.fq.gz_bismark_bt2.CpG_report_for_annotatr.txt,$(BISULFITE_ALIGN_PREFIXES)) \\
-					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed.fq.gz_bismark_bt2.bedGraph.gz,$(BISULFITE_ALIGN_PREFIXES)) \\
-					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed.fq.gz_bismark_bt2.CpG_report.txt,$(BISULFITE_ALIGN_PREFIXES)) \\
-					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed.fq.gz_bismark_bt2.bam,$(BISULFITE_ALIGN_PREFIXES)) \\
+					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_methylSig.txt,$(BISULFITE_ALIGN_PREFIXES)) \\
+					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_annotatr.txt,$(BISULFITE_ALIGN_PREFIXES)) \\
+					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.bedGraph.gz,$(BISULFITE_ALIGN_PREFIXES)) \\
+					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report.txt.gz,$(BISULFITE_ALIGN_PREFIXES)) \\
+					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.bam,$(BISULFITE_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_BIS_TRIM_FASTQCS)/%_trimmed.fq_fastqc.zip,$(BISULFITE_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_BIS_TRIM_FASTQS)/%_trimmed.fq.gz,$(BISULFITE_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_BIS_RAW_FASTQCS)/%_fastqc.zip,$(BISULFITE_ALIGN_PREFIXES))'
@@ -40,36 +40,36 @@ $(DIR_CLASS_SIMPLE)/%_bisulfite_simple_class_for_annotatr.txt : $(DIR_CLASS_SIMP
 	$(PATH_TO_AWK) -v OFS="\\t" \'{ print $$1, $$2, $$3, $$4 }\' $< > $@
 
 # Simple classification for percent methylation
-$(DIR_CLASS_SIMPLE)/%_bisulfite_simple_classification.bed : $(DIR_BIS_BISMARK)/%_bisulfite_trimmed.fq.gz_bismark_bt2.bedGraph.gz
+$(DIR_CLASS_SIMPLE)/%_bisulfite_simple_classification.bed : $(DIR_BIS_BISMARK)/%_bisulfite_trimmed_bismark_bt2.bedGraph.gz
 	$(PATH_TO_R) ../../scripts/classify_simple.R --project $(PROJECT) --inFile $< --outFile $@
 
 # Rules for UCSC bigWig track
-$(DIR_TRACK)/%_trimmed.fq.gz_bismark_bt2.bw : $(DIR_BIS_BISMARK)/%_trimmed.fq.gz_bismark_bt2.bedGraph
+$(DIR_TRACK)/%_trimmed_bismark_bt2.bw : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.bedGraph
 	$(PATH_TO_BDG2BW) $< $(CHROM_PATH) $@
 
-.INTERMEDIATE : $(DIR_BIS_BISMARK)/%_trimmed.fq.gz_bismark_bt2.bedGraph
-$(DIR_BIS_BISMARK)/%_trimmed.fq.gz_bismark_bt2.bedGraph : $(DIR_BIS_BISMARK)/%_trimmed.fq.gz_bismark_bt2.bedGraph.gz
+.INTERMEDIATE : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.bedGraph
+$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.bedGraph : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.bedGraph.gz
 	gunzip -c $< | $(PATH_TO_AWK) \'NR > 1 {print $$0}\' | sort -T . -k1,1 -k2,2n > $@
 
 # Rule for annotatr of extractor results
-$(DIR_SUM_FIGURES)/%_bismark_counts.png : $(DIR_BIS_BISMARK)/%_trimmed.fq.gz_bismark_bt2.CpG_report_for_annotatr.txt
+$(DIR_SUM_FIGURES)/%_bismark_counts.png : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_annotatr.txt
 	$(PATH_TO_R) ../../scripts/annotatr_bisulfite.R --file $< --genome $(GENOME)
 
 # Rule for methylSig input
-$(DIR_BIS_BISMARK)/%_trimmed.fq.gz_bismark_bt2.CpG_report_for_methylSig.txt : $(DIR_BIS_BISMARK)/%_trimmed.fq.gz_bismark_bt2.CpG_report.txt
-	$(PATH_TO_AWK) -f ../../scripts/extractor_to_methylSig.awk $< | sort -T . -k2,2 -k3,3n > $@
+$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_methylSig.txt : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report.txt.gz
+	$(PATH_TO_AWK) -f ../../scripts/extractor_to_methylSig.awk <(gunzip -c $<) | sort -T . -k2,2 -k3,3n > $@
 
 # Rule for annotatr input
-$(DIR_BIS_BISMARK)/%_trimmed.fq.gz_bismark_bt2.CpG_report_for_annotatr.txt : $(DIR_BIS_BISMARK)/%_trimmed.fq.gz_bismark_bt2.CpG_report.txt
-	$(PATH_TO_AWK) -f ../../scripts/extractor_to_annotatr.awk $< | sort -T . -k1,1 -k2,2n > $@
+$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_annotatr.txt : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report.txt.gz
+	$(PATH_TO_AWK) -f ../../scripts/extractor_to_annotatr.awk <(gunzip -c $<) | sort -T . -k1,1 -k2,2n > $@
 
 # Rule for bismark methylation extractor
-$(DIR_BIS_BISMARK)/%_trimmed.fq.gz_bismark_bt2.bedGraph.gz $(DIR_BIS_BISMARK)/%_trimmed.fq.gz_bismark_bt2.CpG_report.txt : $(DIR_BIS_BISMARK)/%_trimmed.fq.gz_bismark_bt2.bam
+$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.bedGraph.gz $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report.txt.gz : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.bam
 	cd $(DIR_BIS_BISMARK); \\
 	$(PATH_TO_EXTRACTOR) $(OPTS_EXTRACTOR) $(<F)
 
 # Rule for bismark alignment
-$(DIR_BIS_BISMARK)/%_trimmed.fq.gz_bismark_bt2.bam : $(DIR_BIS_TRIM_FASTQS)/%_trimmed.fq.gz $(DIR_BIS_TRIM_FASTQCS)/%_trimmed.fq_fastqc.zip
+$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.bam : $(DIR_BIS_TRIM_FASTQS)/%_trimmed.fq.gz $(DIR_BIS_TRIM_FASTQCS)/%_trimmed.fq_fastqc.zip
 	$(PATH_TO_BISMARK) $(OPTS_BISMARK) --output_dir $(@D) --temp_dir $(@D) $<
 	$(PATH_TO_SAMTOOLS) sort $@ $(patsubst %.bam,%,$@)
 	$(PATH_TO_SAMTOOLS) index $@
@@ -115,7 +115,7 @@ for(i in 1:nrow(bisulfite_samples)) {
 	trackEntry = c(
 	  sprintf('track %s_pct_meth', bisulfite_samples[i,'fullHumanID']),
 	  sprintf('parent %s_sample', bisulfite_samples[i,'humanID']),
-	  sprintf('bigDataUrl %s_trimmed.fq.gz_bismark_bt2.bw', bisulfite_samples[i,'fullHumanID']),
+	  sprintf('bigDataUrl %s_trimmed_bismark_bt2.bw', bisulfite_samples[i,'fullHumanID']),
 	  sprintf('shortLabel %s_pct_meth', bisulfite_samples[i,'fullHumanID']),
 	  sprintf('longLabel %s_percent_methylation', bisulfite_samples[i,'fullHumanID']),
 	  'visibility full',

--- a/scripts/sub_init_bis_align.R
+++ b/scripts/sub_init_bis_align.R
@@ -18,7 +18,7 @@ make_var_bis_align = 'BISULFITE_ALIGN_PREREQS := 	$(patsubst %,$(DIR_TRACK)/%_si
 					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.bedGraph.gz,$(BISULFITE_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report.txt.gz,$(BISULFITE_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.bam,$(BISULFITE_ALIGN_PREFIXES)) \\
-					$(patsubst %,$(DIR_BIS_TRIM_FASTQCS)/%_trimmed.fq_fastqc.zip,$(BISULFITE_ALIGN_PREFIXES)) \\
+					$(patsubst %,$(DIR_BIS_TRIM_FASTQCS)/%_trimmed_fastqc.zip,$(BISULFITE_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_BIS_TRIM_FASTQS)/%_trimmed.fq.gz,$(BISULFITE_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_BIS_RAW_FASTQCS)/%_fastqc.zip,$(BISULFITE_ALIGN_PREFIXES))'
 
@@ -69,13 +69,13 @@ $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.bedGraph.gz $(DIR_BIS_BISMARK)/%_trimme
 	$(PATH_TO_EXTRACTOR) $(OPTS_EXTRACTOR) $(<F)
 
 # Rule for bismark alignment
-$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.bam : $(DIR_BIS_TRIM_FASTQS)/%_trimmed.fq.gz $(DIR_BIS_TRIM_FASTQCS)/%_trimmed.fq_fastqc.zip
+$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.bam : $(DIR_BIS_TRIM_FASTQS)/%_trimmed.fq.gz $(DIR_BIS_TRIM_FASTQCS)/%_trimmed_fastqc.zip
 	$(PATH_TO_BISMARK) $(OPTS_BISMARK) --output_dir $(@D) --temp_dir $(@D) $<
 	$(PATH_TO_SAMTOOLS) sort $@ $(patsubst %.bam,%,$@)
 	$(PATH_TO_SAMTOOLS) index $@
 
 # Rule for FastQC on trimmed
-$(DIR_BIS_TRIM_FASTQCS)/%_trimmed.fq_fastqc.zip : $(DIR_BIS_TRIM_FASTQS)/%_trimmed.fq.gz
+$(DIR_BIS_TRIM_FASTQCS)/%_trimmed_fastqc.zip : $(DIR_BIS_TRIM_FASTQS)/%_trimmed.fq.gz
 	$(PATH_TO_FASTQC) $(OPTS_FASTQC) --outdir $(@D) $<
 
 # Rule for trim_galore

--- a/scripts/sub_init_bis_compare.R
+++ b/scripts/sub_init_bis_compare.R
@@ -51,8 +51,8 @@ if(bool_bis_comp) {
 		# Setup variables to put into the makefile
 
 		var_cytfiles = paste(c(
-			paste(sprintf('$(DIR_BIS_BISMARK)/%s_trimmed.fq.gz_bismark_bt2.CpG_report_for_methylSig.txt', groupA$fullHumanID), sep=''),
-			paste(sprintf('$(DIR_BIS_BISMARK)/%s_trimmed.fq.gz_bismark_bt2.CpG_report_for_methylSig.txt', groupB$fullHumanID), sep='')), collapse=',')
+			paste(sprintf('$(DIR_BIS_BISMARK)/%s_trimmed_bismark_bt2.CpG_report_for_methylSig.txt', groupA$fullHumanID), sep=''),
+			paste(sprintf('$(DIR_BIS_BISMARK)/%s_trimmed_bismark_bt2.CpG_report_for_methylSig.txt', groupB$fullHumanID), sep='')), collapse=',')
 		var_sampleids = paste(c(
 			groupA$fullHumanID,
 			groupB$fullHumanID), collapse=',')
@@ -62,8 +62,8 @@ if(bool_bis_comp) {
 		var_comparison = fullHumanID
 
 		var_cytfiles_pre = paste(c(
-			paste(sprintf('$(DIR_BIS_BISMARK)/%s_trimmed.fq.gz_bismark_bt2.CpG_report_for_methylSig.txt', groupA$fullHumanID), sep=''),
-			paste(sprintf('$(DIR_BIS_BISMARK)/%s_trimmed.fq.gz_bismark_bt2.CpG_report_for_methylSig.txt', groupB$fullHumanID), sep='')), collapse=' ')
+			paste(sprintf('$(DIR_BIS_BISMARK)/%s_trimmed_bismark_bt2.CpG_report_for_methylSig.txt', groupA$fullHumanID), sep=''),
+			paste(sprintf('$(DIR_BIS_BISMARK)/%s_trimmed_bismark_bt2.CpG_report_for_methylSig.txt', groupB$fullHumanID), sep='')), collapse=' ')
 
 		# Targets
 		msig_results = sprintf('$(DIR_BIS_MSIG)/%s_$(OPT_DM_TYPE)_methylSig.txt', var_comparison)

--- a/scripts/sub_init_compare_class.R
+++ b/scripts/sub_init_compare_class.R
@@ -60,7 +60,7 @@ $(DIR_PULL_PEPR)/%_pulldown_tmp_signal.txt : $(DIR_PULL_PEPR)/%_pulldown_merged_
 $(DIR_PULL_PEPR)/%_pulldown_tmp_nosignal.txt : $(DIR_PULL_PEPR)/%_pulldown_tmp_signal.txt
 	$(PATH_TO_BEDTOOLS) complement -i $< -g <(sort -T . -k1,1 $(CHROM_PATH)) > $@
 
-.INTERMEDIATE : $(DIR_PULL_PEPR)/%_pulldown_DMdown.txt
+.INTERMEDIATE : $(DIR_PULL_PEPR)/%_pulldown_noDM_signal.txt
 $(DIR_PULL_PEPR)/%_pulldown_noDM_signal.txt : $(DIR_PULL_PEPR)/%_pulldown_tmp_disjoint_noDM.txt $(DIR_PULL_PEPR)/%_pulldown_tmp_signal.txt
 	$(PATH_TO_BEDTOOLS) intersect -a $(word 1, $^) -b $(word 2, $^) | sort -T . -k1,1 -k2,2n > $@
 

--- a/scripts/sub_init_pull_align.R
+++ b/scripts/sub_init_pull_align.R
@@ -12,7 +12,7 @@ make_var_pull_align = 'PULLDOWN_ALIGN_PREREQS :=  $(patsubst %,$(DIR_TRACK)/%_co
 					$(patsubst %,$(DIR_PULL_COVERAGES)/%_coverage.bdg,$(PULLDOWN_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_PULL_COVERAGES)/%_merged_coverage.bdg,$(PULLDOWN_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_PULL_BOWTIE2)/%_trimmed.fq.gz_aligned.bam,$(PULLDOWN_ALIGN_PREFIXES)) \\
-					$(patsubst %,$(DIR_PULL_TRIM_FASTQCS)/%_trimmed.fq_fastqc.zip,$(PULLDOWN_ALIGN_PREFIXES)) \\
+					$(patsubst %,$(DIR_PULL_TRIM_FASTQCS)/%_trimmed_fastqc.zip,$(PULLDOWN_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_PULL_TRIM_FASTQS)/%_trimmed.fq.gz,$(PULLDOWN_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_PULL_RAW_FASTQCS)/%_fastqc.zip,$(PULLDOWN_ALIGN_PREFIXES))'
 
@@ -35,13 +35,13 @@ $(DIR_PULL_COVERAGES)/%_merged_coverage.bdg : $(DIR_PULL_COVERAGES)/%_coverage.b
 	$(PATH_TO_BEDTOOLS) merge -d 20 -i $< | sort -T . -k1,1 -k2,2n > $@
 
 # Rule for bowtie2 alignment
-$(DIR_PULL_BOWTIE2)/%_trimmed.fq.gz_aligned.bam : $(DIR_PULL_TRIM_FASTQS)/%_trimmed.fq.gz $(DIR_PULL_TRIM_FASTQCS)/%_trimmed.fq_fastqc.zip
+$(DIR_PULL_BOWTIE2)/%_trimmed.fq.gz_aligned.bam : $(DIR_PULL_TRIM_FASTQS)/%_trimmed.fq.gz $(DIR_PULL_TRIM_FASTQCS)/%_trimmed_fastqc.zip
 	$(PATH_TO_BOWTIE2) $(OPTS_BOWTIE2) $< | $(PATH_TO_SAMTOOLS) view -bS - > $@
 	$(PATH_TO_SAMTOOLS) sort $@ $(patsubst %.bam,%,$@)
 	$(PATH_TO_SAMTOOLS) index $@
 
 # Rule for FastQC on trimmed
-$(DIR_PULL_TRIM_FASTQCS)/%_trimmed.fq_fastqc.zip : $(DIR_PULL_TRIM_FASTQS)/%_trimmed.fq.gz
+$(DIR_PULL_TRIM_FASTQCS)/%_trimmed_fastqc.zip : $(DIR_PULL_TRIM_FASTQS)/%_trimmed.fq.gz
 	$(PATH_TO_FASTQC) $(OPTS_FASTQC) --outdir $(@D) $<
 
 # Rule for trim_galore

--- a/scripts/sub_init_sample_class.R
+++ b/scripts/sub_init_sample_class.R
@@ -4,9 +4,13 @@
 if(bool_bis_samp || bool_pull_samp) {
 
 make_rule_sample_class_bis_module = '
+.INTERMEDIATE : $(DIR_BIS_BISMARK)/%_bisulfite_trimmed_bismark_bt2.CpG_report.txt
+$(DIR_BIS_BISMARK)/%_bisulfite_trimmed_bismark_bt2.CpG_report.txt : $(DIR_BIS_BISMARK)/%_bisulfite_trimmed_bismark_bt2.CpG_report.txt.gz
+	gunzip -c $< > $@
+
 # Intermediates for the bisulfite piece
-$(DIR_BIS_BISMARK)/%_bisulfite_highmeth.txt $(DIR_BIS_BISMARK)/%_bisulfite_lowmeth.txt $(DIR_BIS_BISMARK)/%_bisulfite_nometh_signal.txt $(DIR_BIS_BISMARK)/%_bisulfite_nometh_nosignal.txt : $(DIR_BIS_BISMARK)/%_bisulfite_trimmed_bismark_bt2.CpG_report.txt.gz
-	$(PATH_TO_AWK) -f ../../scripts/classify_prepare_bisulfite_sample.awk <(gunzip -c $<)
+$(DIR_BIS_BISMARK)/%_bisulfite_highmeth.txt $(DIR_BIS_BISMARK)/%_bisulfite_lowmeth.txt $(DIR_BIS_BISMARK)/%_bisulfite_nometh_signal.txt $(DIR_BIS_BISMARK)/%_bisulfite_nometh_nosignal.txt : $(DIR_BIS_BISMARK)/%_bisulfite_trimmed_bismark_bt2.CpG_report.txt
+	$(PATH_TO_AWK) -f ../../scripts/classify_prepare_bisulfite_sample.awk $<
 '
 
 make_rule_sample_class_pull_module = '

--- a/scripts/sub_init_sample_class.R
+++ b/scripts/sub_init_sample_class.R
@@ -5,8 +5,8 @@ if(bool_bis_samp || bool_pull_samp) {
 
 make_rule_sample_class_bis_module = '
 # Intermediates for the bisulfite piece
-$(DIR_BIS_BISMARK)/%_bisulfite_highmeth.txt $(DIR_BIS_BISMARK)/%_bisulfite_lowmeth.txt $(DIR_BIS_BISMARK)/%_bisulfite_nometh_signal.txt $(DIR_BIS_BISMARK)/%_bisulfite_nometh_nosignal.txt : $(DIR_BIS_BISMARK)/%_bisulfite_trimmed.fq.gz_bismark_bt2.CpG_report.txt
-	$(PATH_TO_AWK) -f ../../scripts/classify_prepare_bisulfite_sample.awk $<
+$(DIR_BIS_BISMARK)/%_bisulfite_highmeth.txt $(DIR_BIS_BISMARK)/%_bisulfite_lowmeth.txt $(DIR_BIS_BISMARK)/%_bisulfite_nometh_signal.txt $(DIR_BIS_BISMARK)/%_bisulfite_nometh_nosignal.txt : $(DIR_BIS_BISMARK)/%_bisulfite_trimmed_bismark_bt2.CpG_report.txt.gz
+	$(PATH_TO_AWK) -f ../../scripts/classify_prepare_bisulfite_sample.awk <(gunzip -c $<)
 '
 
 make_rule_sample_class_pull_module = '


### PR DESCRIPTION
- Various changes needed for changes coming from bismark v0.16.1.
- Changes needed for FastQC v0.11.5.
- Updated install instructions for R packages.
- Add intergenic annotations to annotatr runs.
- Alteration of bismark coverage plots to xlim = 0, 500 for interpretability.
