### PR TITLE
Merge v0.1.0-beta into master

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The mint pipeline can be used for any combination of the following experimental 
 3. Put a tab-delimited annotation file `project_name_annotation.txt` in the `mint/projects` directory. It **must** have the following 9 columns. See below for examples.
 	1. `projectID`: The name of the project.
 	2. `sampleID`: An alphanumeric ID (perhaps from SRA, GEO, a sequencing core, etc.). Typically these will be the names of the `.fastq` files.
-	3. `humanID`: The human readable ID for the sample.
+	3. `humanID`: The human readable ID for the sample to make finding files easier.
 	4. `pulldown`: A binary value indicating whether the sample is the result of a pulldown experiment (1) or not (0).
 	5. `bisulfite`: A binary value indicating whether the sample is the result of a bisulfite-conversion experiment (1) or not (0).
 	6. `mc`: A binary value indicating whether the sample represents 5mc methylation.

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,6 +1,6 @@
 ### Versions
 
-This file gives the current version of software used in the pipeline as of March 31, 2016.
+This file gives the current version of software used in the pipeline as of May 15, 2016.
 
 * bedtools v2.25.0
 * bedops v2.4.14

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -9,8 +9,8 @@ This file gives the current version of software used in the pipeline as of March
 * macs2 v2.1.0.20140616
 * PePr v1.0.9
 * R v3.2.5
-	* annotatr v0.7.0
-	* methylSig v0.4.2
+	* annotatr v0.7.1
+	* methylSig v0.4.3
 * samtools v0.1.19
 * trim_galore v0.4.1
 * cutadapt v1.9.1

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -7,7 +7,7 @@ This file gives the current version of software used in the pipeline as of May 1
 * bismark v0.16.1
 * bowtie2 v2.2.4
 * macs2 v2.1.0.20140616
-* PePr v1.1.1
+* PePr v1.1.3
 * R v3.2.5
 	* annotatr v0.7.1
 	* methylSig v0.4.3

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -7,7 +7,7 @@ This file gives the current version of software used in the pipeline as of May 1
 * bismark v0.16.1
 * bowtie2 v2.2.4
 * macs2 v2.1.0.20140616
-* PePr v1.0.9
+* PePr v1.1.1
 * R v3.2.5
 	* annotatr v0.7.1
 	* methylSig v0.4.3

--- a/init.R
+++ b/init.R
@@ -112,3 +112,5 @@ source('scripts/sub_init_bis_compare.R')
 source('scripts/sub_init_pull_compare.R')
 
 source('scripts/sub_init_compare_class.R')
+
+source('scripts/sub_init_clean.R')

--- a/scripts/annotatr_bisulfite.R
+++ b/scripts/annotatr_bisulfite.R
@@ -233,3 +233,5 @@ if(suffix == 'methylSig') {
 	ggplot2::ggsave(filename = cat_prop_genes_png, plot = plot_cat_prop_genes, width = 8, height = 8)
 
 }
+
+save.image(file = sprintf('RData/%s_%s_annotatr_analysis.RData', sample, suffix))

--- a/scripts/annotatr_bisulfite.R
+++ b/scripts/annotatr_bisulfite.R
@@ -131,13 +131,13 @@ plot_counts = plot_annotation(
 	y_label = '# CpGs')
 ggplot2::ggsave(filename = counts_png, plot = plot_counts, width = 8, height = 8)
 
-cocounts_png = sprintf('summary/figures/%s_%s_cocounts.png', sample, suffix)
-plot_cocounts = plot_coannotations(
-	annotated_regions = ar,
-	annotation_order = a_all_order,
-	plot_title = sprintf('%s CpGs in pairs of annotations', sample),
-	axes_label = 'Annotations')
-ggplot2::ggsave(filename = cocounts_png, plot = plot_cocounts, width = 8, height = 8)
+# cocounts_png = sprintf('summary/figures/%s_%s_cocounts.png', sample, suffix)
+# plot_cocounts = plot_coannotations(
+# 	annotated_regions = ar,
+# 	annotation_order = a_all_order,
+# 	plot_title = sprintf('%s CpGs in pairs of annotations', sample),
+# 	axes_label = 'Annotations')
+# ggplot2::ggsave(filename = cocounts_png, plot = plot_cocounts, width = 8, height = 8)
 
 if(suffix == 'bismark') {
 	coverage_png = sprintf('summary/figures/%s_%s_coverage.png', sample, suffix)

--- a/scripts/annotatr_classification.R
+++ b/scripts/annotatr_classification.R
@@ -137,8 +137,8 @@ if(class_type == 'simple') {
 		'no_DM')
 } else if (class_type == 'PePr') {
 	cats_order = c(
-		'hyper',
-		'hypo')
+		'chip1',
+		'chip2')
 }
 
 ###############################################################

--- a/scripts/annotatr_classification.R
+++ b/scripts/annotatr_classification.R
@@ -2,6 +2,7 @@ library(annotatr)
 library(readr)
 library(ggplot2)
 library(optparse)
+library(GenomicRanges)
 
 option_list = list(
   make_option('--file', type='character'),
@@ -183,6 +184,21 @@ ggplot2::ggsave(filename = counts_png, plot = plot_counts, width = 8, height = 8
 # 		axes_label = 'Annotations')
 # 	ggplot2::ggsave(filename = cocounts_png, plot = plot_cocounts, width = 8, height = 8)
 # }
+
+# Histogram of region (peak) widths for *pulldown_simple* and PePr inputs
+if( (class_type == 'simple' && grepl('pulldown')) || class_type == 'PePr' ) {
+	widths = data.frame(
+		region = 1:length(r),
+		width = end(r) - start(r), stringsAsFactors=F)
+
+	widths_png = sprintf('summary/figures/%s_peak_widths.png', prefix)
+	plot_region_widths = ggplot(data = widths, aes(x = width, y=..density..)) +
+		scale_x_log10() + geom_histogram(stat = 'bin', fill = NA, color='gray', bins=30) +
+		theme_bw() +
+		xlab('Peak Widths (log10 scale)') +
+		ggtitle(sprintf('%s peak widths', prefix))
+	ggplot2::ggsave(filename = widths_png, plot = plot_region_widths, width = 6, height = 6)
+}
 
 # Regions split by category and stacked by CpG annotations (count)
 cat_count_cpgs_png = sprintf('summary/figures/%s_cat_count_cpgs.png', prefix)

--- a/scripts/annotatr_classification.R
+++ b/scripts/annotatr_classification.R
@@ -186,7 +186,7 @@ ggplot2::ggsave(filename = counts_png, plot = plot_counts, width = 8, height = 8
 # }
 
 # Histogram of region (peak) widths for *pulldown_simple* and PePr inputs
-if( (class_type == 'simple' && grepl('pulldown')) || class_type == 'PePr' ) {
+if( (class_type == 'simple' && grepl('pulldown', prefix)) || class_type == 'PePr' ) {
 	widths = data.frame(
 		region = 1:length(r),
 		width = end(r) - start(r), stringsAsFactors=F)

--- a/scripts/annotatr_classification.R
+++ b/scripts/annotatr_classification.R
@@ -227,3 +227,5 @@ plot_cat_prop_genes = plot_categorical(
   x_label = sprintf('%s classification', display_type),
   y_label = 'Proportion')
 ggplot2::ggsave(filename = cat_prop_genes_png, plot = plot_cat_prop_genes, width = 8, height = 8)
+
+save.image(file = sprintf('RData/%s_annotatr_analysis.RData', prefix))

--- a/scripts/annotatr_classification.R
+++ b/scripts/annotatr_classification.R
@@ -173,16 +173,16 @@ plot_counts = plot_annotation(
 ggplot2::ggsave(filename = counts_png, plot = plot_counts, width = 8, height = 8)
 
 # Other classifications are too big for this
-if(class_type == 'simple' || class_type == 'PePr') {
-	# Heatmap of regions in pairs of annotations
-	cocounts_png = sprintf('summary/figures/%s_cocounts.png', prefix)
-	plot_cocounts = plot_coannotations(
-		annotated_regions = ar,
-		annotation_order = a_all_order,
-		plot_title = sprintf('%s regions in pairs of annotations', prefix),
-		axes_label = 'Annotations')
-	ggplot2::ggsave(filename = cocounts_png, plot = plot_cocounts, width = 8, height = 8)
-}
+# if(class_type == 'simple' || class_type == 'PePr') {
+# 	# Heatmap of regions in pairs of annotations
+# 	cocounts_png = sprintf('summary/figures/%s_cocounts.png', prefix)
+# 	plot_cocounts = plot_coannotations(
+# 		annotated_regions = ar,
+# 		annotation_order = a_all_order,
+# 		plot_title = sprintf('%s regions in pairs of annotations', prefix),
+# 		axes_label = 'Annotations')
+# 	ggplot2::ggsave(filename = cocounts_png, plot = plot_cocounts, width = 8, height = 8)
+# }
 
 # Regions split by category and stacked by CpG annotations (count)
 cat_count_cpgs_png = sprintf('summary/figures/%s_cat_count_cpgs.png', prefix)

--- a/scripts/classify_prepare_bisulfite_sample.awk
+++ b/scripts/classify_prepare_bisulfite_sample.awk
@@ -3,20 +3,20 @@ BEGIN {OFS="\t"}
 {
 	outFile = FILENAME
 
-	if ( ($4 + $5 >= 5) && ($4 / ($4 + $5) >= 0.5) ) {
-		### count >= 5 and meth >= 50%
+	if ( ($4 + $5 >= MIN_COV) && ($4 / ($4 + $5) >= 0.5) ) {
+		### count >= MIN_COV and meth >= 50%
 		sub(/_trimmed_bismark_bt2\.CpG_report\.txt/, "_highmeth.txt", outFile)
 		print $1, $2 - 1, $2 > outFile
-	} else if ( ($4 + $5 >= 5) && ($4 / ($4 + $5) > 0.05) && ($4 / ($4 + $5) < 0.5) ) {
-		### count >= 5 and 5% < meth < 50%
+	} else if ( ($4 + $5 >= MIN_COV) && ($4 / ($4 + $5) > 0.05) && ($4 / ($4 + $5) < 0.5) ) {
+		### count >= MIN_COV and 5% < meth < 50%
 		sub(/_trimmed_bismark_bt2\.CpG_report\.txt/, "_lowmeth.txt", outFile)
 		print $1, $2 - 1, $2 > outFile
-	} else if ( ($4 + $5 >= 5) && ($4 / ($4 + $5) <= 0.05) ) {
-		### count >= 5 and meth < 5%
+	} else if ( ($4 + $5 >= MIN_COV) && ($4 / ($4 + $5) <= 0.05) ) {
+		### count >= MIN_COV and meth < 5%
 		sub(/_trimmed_bismark_bt2\.CpG_report\.txt/, "_nometh_signal.txt", outFile)
 		print $1, $2 - 1, $2 > outFile
 	} else {
-		### count <= 4
+		### count < MIN_COV
 		sub(/_trimmed_bismark_bt2\.CpG_report\.txt/, "_nometh_nosignal.txt", outFile)
 		print $1, $2 - 1, $2 > outFile
 	}

--- a/scripts/methylSig_run.R
+++ b/scripts/methylSig_run.R
@@ -60,12 +60,9 @@ meth = methylSigReadData(
     num.cores = opt$ncores,
     quiet= opt$quiet)
 
-save(meth, file=sprintf('bisulfite/methylsig_calls/%s_raw_CpG_data.RData', prefix))
-
 if(opt$dmtype == 'DMR') {
     message('Doing tiled analysis')
     meth_tiled = methylSigTile(meth, win.size = opt$winsize.tile)
-	save(meth_tiled, file=sprintf('bisulfite/methylsig_calls/%s_raw_region_data.RData', prefix))
 
     diff_meth = methylSigCalc(
         meth_tiled,
@@ -99,3 +96,5 @@ if(opt$dmtype == 'DMR') {
 } else {
 	stop('Error in methylSig run. Invalid OPT_DM_TYPE in config.mk. Must be DMC for CpG resolution or DMR for regions of winsize.tile resolution.')
 }
+
+save.image(file=sprintf('RData/%s_analysis.RData', prefix))

--- a/scripts/pepr_combine.sh
+++ b/scripts/pepr_combine.sh
@@ -3,32 +3,32 @@ set -e
 set -u
 set -o pipefail
 
-peprUp=$1
-peprDown=$2
+peprChip1=$1
+peprChip2=$2
 peprCombined=$3
 
-upPrefix=`basename ${peprUp} __PePr_up_peaks.bed`
-downPrefix=`basename ${peprDown} __PePr_down_peaks.bed`
+upPrefix=`basename ${peprChip1} __PePr_chip1_peaks.bed`
+downPrefix=`basename ${peprChip2} __PePr_chip2_peaks.bed`
 
-disUp=pulldown/pepr_peaks/${upPrefix}_disjoint_up.bed
-disDown=pulldown/pepr_peaks/${upPrefix}_disjoint_down.bed 
-
-bedops --difference \
-	<(cut -f 1-3 ${peprUp}) \
-	<(cut -f 1-3 ${peprDown}) \
-| sort -T . -k1,1 -k2,2n \
-> $disUp
+disChip1=pulldown/pepr_peaks/${upPrefix}_disjoint_chip1.bed
+disChip2=pulldown/pepr_peaks/${upPrefix}_disjoint_chip2.bed
 
 bedops --difference \
-	<(cut -f 1-3 ${peprDown}) \
-	<(cut -f 1-3 ${peprUp}) \
+	<(cut -f 1-3 ${peprChip1}) \
+	<(cut -f 1-3 ${peprChip2}) \
 | sort -T . -k1,1 -k2,2n \
-> $disDown
+> $disChip1
+
+bedops --difference \
+	<(cut -f 1-3 ${peprChip2}) \
+	<(cut -f 1-3 ${peprChip1}) \
+| sort -T . -k1,1 -k2,2n \
+> $disChip2
 
 cat \
-  <(awk -v OFS="\t" '{ print $1, $2, $3, "hyper", "1000", ".", $2, $3, "0,0,255" }' ${disUp}) \
-  <(awk -v OFS="\t" '{ print $1, $2, $3, "hypo", "1000", ".", $2, $3, "102,102,255" }' ${disDown}) \
+  <(awk -v OFS="\t" '{ print $1, $2, $3, "chip1", "1000", ".", $2, $3, "0,0,255" }' ${disChip1}) \
+  <(awk -v OFS="\t" '{ print $1, $2, $3, "chip2", "1000", ".", $2, $3, "102,102,255" }' ${disChip2}) \
 | sort -T . -k1,1 -k2,2n > ${peprCombined}
 
 # Clean up
-rm -f ${disUp} ${disDown}
+rm -f ${disChip1} ${disChip2}

--- a/scripts/sub_init_bis_align.R
+++ b/scripts/sub_init_bis_align.R
@@ -13,8 +13,6 @@ make_var_bis_align = 'BISULFITE_ALIGN_PREREQS := 	$(patsubst %,$(DIR_TRACK)/%_si
 					$(patsubst %,$(DIR_TRACK)/%_trimmed_bismark_bt2.bw,$(BISULFITE_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_SUM_FIGURES)/%_bismark_counts.png,$(BISULFITE_ALIGN_PREFIXES))\\
 					$(patsubst %,$(DIR_SUM_FIGURES)/%_simple_class_counts.png,$(BISULFITE_ALIGN_PREFIXES))\\
-					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_methylSig.txt,$(BISULFITE_ALIGN_PREFIXES)) \\
-					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_annotatr.txt,$(BISULFITE_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.bedGraph.gz,$(BISULFITE_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report.txt.gz,$(BISULFITE_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.bam,$(BISULFITE_ALIGN_PREFIXES)) \\
@@ -56,10 +54,12 @@ $(DIR_SUM_FIGURES)/%_bismark_counts.png : $(DIR_BIS_BISMARK)/%_trimmed_bismark_b
 	$(PATH_TO_R) ../../scripts/annotatr_bisulfite.R --file $< --genome $(GENOME)
 
 # Rule for methylSig input
+.INTERMEDIATE : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_methylSig.txt
 $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_methylSig.txt : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report.txt.gz
 	$(PATH_TO_AWK) -f ../../scripts/extractor_to_methylSig.awk <(gunzip -c $<) | sort -T . -k2,2 -k3,3n > $@
 
 # Rule for annotatr input
+.INTERMEDIATE : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_annotatr.txt
 $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_annotatr.txt : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report.txt.gz
 	$(PATH_TO_AWK) -f ../../scripts/extractor_to_annotatr.awk <(gunzip -c $<) | sort -T . -k1,1 -k2,2n > $@
 

--- a/scripts/sub_init_bis_align.R
+++ b/scripts/sub_init_bis_align.R
@@ -11,8 +11,8 @@ BISULFITE_ALIGN_PREFIXES := %s', paste(bisulfite_samples$fullHumanID, collapse='
 make_var_bis_align = 'BISULFITE_ALIGN_PREREQS := 	$(patsubst %,$(DIR_TRACK)/%_simple_classification.bb,$(BISULFITE_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_CLASS_SIMPLE)/%_simple_classification.bed,$(BISULFITE_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_TRACK)/%_trimmed_bismark_bt2.bw,$(BISULFITE_ALIGN_PREFIXES)) \\
-					$(patsubst %,$(DIR_SUM_FIGURES)/%_bismark_counts.png,$(BISULFITE_ALIGN_PREFIXES))\\
-					$(patsubst %,$(DIR_SUM_FIGURES)/%_simple_class_counts.png,$(BISULFITE_ALIGN_PREFIXES))\\
+					$(patsubst %,$(DIR_RDATA)/%_bismark_annotatr_analysis.RData,$(BISULFITE_ALIGN_PREFIXES))\\
+					$(patsubst %,$(DIR_RDATA)/%_simple_class_annotatr_analysis.RData,$(BISULFITE_ALIGN_PREFIXES))\\
 					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.bedGraph.gz,$(BISULFITE_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report.txt.gz,$(BISULFITE_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.bam,$(BISULFITE_ALIGN_PREFIXES)) \\
@@ -35,7 +35,7 @@ $(DIR_TRACK)/%_bisulfite_simple_classification.bb : $(DIR_CLASS_SIMPLE)/%_bisulf
 	$(PATH_TO_BDG2BB) $< $(CHROM_PATH) $@
 
 # Rule for annotatr of simple classification
-$(DIR_SUM_FIGURES)/%_bisulfite_simple_class_counts.png : $(DIR_CLASS_SIMPLE)/%_bisulfite_simple_class_for_annotatr.txt
+$(DIR_RDATA)/%_simple_class_annotatr_analysis.RData : $(DIR_CLASS_SIMPLE)/%_bisulfite_simple_class_for_annotatr.txt
 	$(PATH_TO_R) ../../scripts/annotatr_classification.R --file $< --genome $(GENOME)
 
 .INTERMEDIATE : $(DIR_CLASS_SIMPLE)/%_bisulfite_simple_class_for_annotatr.txt
@@ -55,7 +55,7 @@ $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.bedGraph : $(DIR_BIS_BISMARK)/%_trimmed
 	gunzip -c $< | $(PATH_TO_AWK) \'NR > 1 {print $$0}\' | sort -T . -k1,1 -k2,2n > $@
 
 # Rule for annotatr of extractor results
-$(DIR_SUM_FIGURES)/%_bismark_counts.png : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_annotatr.txt
+$(DIR_RDATA)/%_bismark_annotatr_analysis.RData : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_annotatr.txt
 	$(PATH_TO_R) ../../scripts/annotatr_bisulfite.R --file $< --genome $(GENOME)
 
 # Rule for annotatr input

--- a/scripts/sub_init_bis_align.R
+++ b/scripts/sub_init_bis_align.R
@@ -103,24 +103,24 @@ cat(make_var_bis_align, file = file_make, sep = '\n', append = TRUE)
 cat(make_var_bis_align_clean_tmp, file = file_make, sep = '\n', append = TRUE)
 cat(make_rule_bis_align, file = file_make, sep = '\n', append = TRUE)
 
-#######################################
+# ######################################
 # PBS script
-# bisulfite_align_q = c(
-# 	'#!/bin/bash',
-# 	'#### Begin PBS preamble',
-# 	'#PBS -N bis_align',
-# 	'#PBS -l procs=10,mem=80gb,walltime=6:00:00',
-# 	'#PBS -A sartor_lab',
-# 	'#PBS -q first',
-# 	'#PBS -M rcavalca@umich.edu',
-# 	'#PBS -m abe',
-# 	'#PBS -j oe',
-# 	'#PBS -V',
-# 	'#### End PBS preamble',
-# 	'# Put your job commands after this line',
-# 	sprintf('cd ~/latte/mint/projects/%s/',project),
-# 	'make -j 2 bisulfite_align')
-# cat(bisulfite_align_q, file=sprintf('projects/%s/pbs_jobs/bisulfite_align.q', project), sep='\n')
+bisulfite_align_q = c(
+	'#!/bin/bash',
+	'#### Begin PBS preamble',
+	'#PBS -N bis_align',
+	'#PBS -l nodes=1:ppn=15,walltime=24:00:00,pmem=8gb',
+	'#PBS -A sartor_lab',
+	'#PBS -q first',
+	'#PBS -M rcavalca@umich.edu',
+	'#PBS -m abe',
+	'#PBS -j oe',
+	'#PBS -V',
+	'#### End PBS preamble',
+	'# Put your job commands after this line',
+	sprintf('cd ~/latte/mint/projects/%s/',project),
+	'make -j 3 bisulfite_align')
+cat(bisulfite_align_q, file=sprintf('projects/%s/pbs_jobs/bisulfite_align.q', project), sep='\n')
 
 for(i in 1:nrow(bisulfite_samples)) {
 	# trackDb.txt entry for Bismark methylation calls

--- a/scripts/sub_init_bis_align.R
+++ b/scripts/sub_init_bis_align.R
@@ -22,7 +22,6 @@ make_var_bis_align = 'BISULFITE_ALIGN_PREREQS := 	$(patsubst %,$(DIR_TRACK)/%_si
 
 make_var_bis_align_clean_tmp = 'BISFULITE_ALIGN_CLEAN_TMP := $(patsubst %,$(DIR_CLASS_SIMPLE)/%_bisulfite_simple_class_for_annotatr.txt,$(BISULFITE_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.bedGraph,$(BISULFITE_ALIGN_PREFIXES)) \\
-					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_methylSig.txt,$(BISULFITE_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_annotatr.txt,$(BISULFITE_ALIGN_PREFIXES))
 '
 

--- a/scripts/sub_init_bis_align.R
+++ b/scripts/sub_init_bis_align.R
@@ -35,7 +35,7 @@ $(DIR_TRACK)/%_bisulfite_simple_classification.bb : $(DIR_CLASS_SIMPLE)/%_bisulf
 	$(PATH_TO_BDG2BB) $< $(CHROM_PATH) $@
 
 # Rule for annotatr of simple classification
-$(DIR_RDATA)/%_simple_class_annotatr_analysis.RData : $(DIR_CLASS_SIMPLE)/%_bisulfite_simple_class_for_annotatr.txt
+$(DIR_RDATA)/%_bisulfite_simple_class_annotatr_analysis.RData : $(DIR_CLASS_SIMPLE)/%_bisulfite_simple_class_for_annotatr.txt
 	$(PATH_TO_R) ../../scripts/annotatr_classification.R --file $< --genome $(GENOME)
 
 .INTERMEDIATE : $(DIR_CLASS_SIMPLE)/%_bisulfite_simple_class_for_annotatr.txt

--- a/scripts/sub_init_bis_align.R
+++ b/scripts/sub_init_bis_align.R
@@ -59,11 +59,6 @@ $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.bedGraph : $(DIR_BIS_BISMARK)/%_trimmed
 $(DIR_SUM_FIGURES)/%_bismark_counts.png : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_annotatr.txt
 	$(PATH_TO_R) ../../scripts/annotatr_bisulfite.R --file $< --genome $(GENOME)
 
-# Rule for methylSig input
-.INTERMEDIATE : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_methylSig.txt
-$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_methylSig.txt : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report.txt.gz
-	$(PATH_TO_AWK) -f ../../scripts/extractor_to_methylSig.awk <(gunzip -c $<) | sort -T . -k2,2 -k3,3n > $@
-
 # Rule for annotatr input
 .INTERMEDIATE : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_annotatr.txt
 $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_annotatr.txt : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report.txt.gz

--- a/scripts/sub_init_bis_align.R
+++ b/scripts/sub_init_bis_align.R
@@ -20,6 +20,12 @@ make_var_bis_align = 'BISULFITE_ALIGN_PREREQS := 	$(patsubst %,$(DIR_TRACK)/%_si
 					$(patsubst %,$(DIR_BIS_TRIM_FASTQS)/%_trimmed.fq.gz,$(BISULFITE_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_BIS_RAW_FASTQCS)/%_fastqc.zip,$(BISULFITE_ALIGN_PREFIXES))'
 
+make_var_bis_align_clean_tmp = 'BISFULITE_ALIGN_CLEAN_TMP := $(patsubst %,$(DIR_CLASS_SIMPLE)/%_bisulfite_simple_class_for_annotatr.txt,$(BISULFITE_ALIGN_PREFIXES)) \\
+					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.bedGraph,$(BISULFITE_ALIGN_PREFIXES)) \\
+					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_methylSig.txt,$(BISULFITE_ALIGN_PREFIXES)) \\
+					$(patsubst %,$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_annotatr.txt,$(BISULFITE_ALIGN_PREFIXES))
+'
+
 # NOTE: This cannot be indented because they would mess up the makefile
 make_rule_bis_align = '
 .PHONY : bisulfite_align
@@ -85,10 +91,16 @@ $(DIR_BIS_TRIM_FASTQS)/%_trimmed.fq.gz : $(DIR_BIS_RAW_FASTQCS)/%_fastqc.zip
 # Rule for FastQC on raw
 $(DIR_BIS_RAW_FASTQCS)/%_fastqc.zip :
 	$(PATH_TO_FASTQC) $(OPTS_FASTQC) --outdir $(@D) $(DIR_BIS_RAW_FASTQS)/$*.fastq.gz
+
+# Rule to delete all temporary files from make bis_align
+.PHONY : clean_bisulfite_align_tmp
+clean_bisulfite_align_tmp :
+	rm -f $(BISFULITE_ALIGN_CLEAN_TMP)
 '
 
 cat(make_var_bis_align_prefix, file = file_make, sep = '\n', append = TRUE)
 cat(make_var_bis_align, file = file_make, sep = '\n', append = TRUE)
+cat(make_var_bis_align_clean_tmp, file = file_make, sep = '\n', append = TRUE)
 cat(make_rule_bis_align, file = file_make, sep = '\n', append = TRUE)
 
 #######################################

--- a/scripts/sub_init_bis_compare.R
+++ b/scripts/sub_init_bis_compare.R
@@ -96,6 +96,10 @@ if(bool_bis_comp) {
 			sprintf('.PHONY : bisulfite_compare_%s', i),
 			sprintf('bisulfite_compare_%s : $(BISULFITE_COMPARE_%s_PREREQS)', i, i),
 			'',
+			'# Rule for methylSig input
+			.INTERMEDIATE : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_methylSig.txt
+			$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_methylSig.txt : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report.txt.gz
+				$(PATH_TO_AWK) -f ../../scripts/extractor_to_methylSig.awk <(gunzip -c $<) | sort -T . -k2,2 -k3,3n > $@',
 			sprintf('%s : %s', msig_results, var_cytfiles_pre),
 			sprintf('	$(PATH_TO_R) ../../scripts/methylSig_run.R --project $(PROJECT) --cytfiles $(BISULFITE_COMPARE_%s_CYTFILES) --sampleids $(BISULFITE_COMPARE_%s_SAMPLEIDS) --treatment $(BISULFITE_COMPARE_%s_TREATMENT) --assembly $(GENOME) --pipeline mint --outprefix $(BISULFITE_COMPARE_%s_COMPARISON) $(OPTS_METHYLSIG_%s)', i, i, i, i, var_comparison),
 			'',

--- a/scripts/sub_init_bis_compare.R
+++ b/scripts/sub_init_bis_compare.R
@@ -85,7 +85,7 @@ if(bool_bis_comp) {
 			sprintf('BISULFITE_COMPARE_%s_SAMPLEIDS := %s', i, var_sampleids),
 			sprintf('BISULFITE_COMPARE_%s_TREATMENT := %s', i, var_treatment),
 			sprintf('BISULFITE_COMPARE_%s_COMPARISON := %s_$(OPT_DM_TYPE)_methylSig', i, var_comparison),
-			sprintf('BISULFITE_COMPARE_%s_CLEAN_TMP := %s %s', i, msig_tmp_results, annotatr_bed))
+			sprintf('BISULFITE_COMPARE_%s_CLEAN_TMP := %s %s %s', i, msig_tmp_results, annotatr_bed, var_cytfiles_pre))
 		cat(make_vars_bis_compare, file = file_make, sep='\n', append=T)
 
 		########################################################################

--- a/scripts/sub_init_bis_compare.R
+++ b/scripts/sub_init_bis_compare.R
@@ -162,20 +162,20 @@ OPTS_METHYLSIG_%s = --context CpG --resolution base --destranded TRUE --maxcount
 
 	#######################################
 	# PBS script
-	# bisulfite_compare_q = c(
-	# 	'#!/bin/bash',
-	# 	'#### Begin PBS preamble',
-	# 	'#PBS -N bis_compare',
-	# 	'#PBS -l procs=4,mem=32gb,walltime=6:00:00',
-	# 	'#PBS -A sartor_lab',
-	# 	'#PBS -q first',
-	# 	'#PBS -M rcavalca@umich.edu',
-	# 	'#PBS -m abe',
-	# 	'#PBS -j oe',
-	# 	'#PBS -V',
-	# 	'#### End PBS preamble',
-	# 	'# Put your job commands after this line',
-	# 	sprintf('cd ~/latte/mint/projects/%s/',project),
-	# 	'make -j 4 bisulfite_compare')
-	# cat(bisulfite_compare_q, file=sprintf('projects/%s/pbs_jobs/bisulfite_compare.q', project), sep='\n')
+	bisulfite_compare_q = c(
+		'#!/bin/bash',
+		'#### Begin PBS preamble',
+		'#PBS -N bis_compare',
+		'#PBS -l nodes=1:ppn=4,walltime=24:00:00,pmem=8gb',
+		'#PBS -A sartor_lab',
+		'#PBS -q first',
+		'#PBS -M rcavalca@umich.edu',
+		'#PBS -m abe',
+		'#PBS -j oe',
+		'#PBS -V',
+		'#### End PBS preamble',
+		'# Put your job commands after this line',
+		sprintf('cd ~/latte/mint/projects/%s/',project),
+		'make -j 4 bisulfite_compare')
+	cat(bisulfite_compare_q, file=sprintf('projects/%s/pbs_jobs/bisulfite_compare.q', project), sep='\n')
 }

--- a/scripts/sub_init_bis_compare.R
+++ b/scripts/sub_init_bis_compare.R
@@ -113,15 +113,15 @@ if(bool_bis_comp) {
 			sprintf('%s : %s', msig_bigwig, msig_tmp_results),
 			'	$(PATH_TO_BDG2BW) $^ $(CHROM_PATH) $@',
 			'',
-			sprintf('.PHONY : bisulfite_compare_clean_tmp_%s', i),
-			sprintf('bisulfite_compare_clean_tmp_%s :
+			sprintf('.PHONY : clean_bisulfite_compare_tmp_%s', i),
+			sprintf('clean_bisulfite_compare_tmp_%s :
 				rm -f $(BISULFITE_COMPARE_%s_CLEAN_TMP)', i, i),
 			'')
 		cat(make_rule_bis_compare, file = file_make, sep='\n', append=T)
 
 		# Track the number of bisulfite compares and bisulfite clean tmps
 		bisulfite_compares = c(bisulfite_compares, sprintf('bisulfite_compare_%s', i))
-		bisulfite_clean_tmps = c(bisulfite_clean_tmps, sprintf('bisulfite_compare_clean_tmp_%s', i))
+		bisulfite_clean_tmps = c(bisulfite_clean_tmps, sprintf('clean_bisulfite_compare_tmp_%s', i))
 
 		########################################################################
 		# OPTS for config.mk

--- a/scripts/sub_init_bis_compare.R
+++ b/scripts/sub_init_bis_compare.R
@@ -96,10 +96,10 @@ if(bool_bis_comp) {
 			sprintf('.PHONY : bisulfite_compare_%s', i),
 			sprintf('bisulfite_compare_%s : $(BISULFITE_COMPARE_%s_PREREQS)', i, i),
 			'',
-			'# Rule for methylSig input
-			.INTERMEDIATE : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_methylSig.txt
-			$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_methylSig.txt : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report.txt.gz
-				$(PATH_TO_AWK) -f ../../scripts/extractor_to_methylSig.awk <(gunzip -c $<) | sort -T . -k2,2 -k3,3n > $@',
+'# Rule for methylSig input
+.INTERMEDIATE : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_methylSig.txt
+$(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_methylSig.txt : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report.txt.gz
+	$(PATH_TO_AWK) -f ../../scripts/extractor_to_methylSig.awk <(gunzip -c $<) | sort -T . -k2,2 -k3,3n > $@',
 			sprintf('%s : %s', msig_results, var_cytfiles_pre),
 			sprintf('	$(PATH_TO_R) ../../scripts/methylSig_run.R --project $(PROJECT) --cytfiles $(BISULFITE_COMPARE_%s_CYTFILES) --sampleids $(BISULFITE_COMPARE_%s_SAMPLEIDS) --treatment $(BISULFITE_COMPARE_%s_TREATMENT) --assembly $(GENOME) --pipeline mint --outprefix $(BISULFITE_COMPARE_%s_COMPARISON) $(OPTS_METHYLSIG_%s)', i, i, i, i, var_comparison),
 			'',

--- a/scripts/sub_init_bis_compare.R
+++ b/scripts/sub_init_bis_compare.R
@@ -94,7 +94,7 @@ if(bool_bis_comp) {
 		# Write the bisulfite_compare rule for this comparison
 		make_rule_bis_compare = c(
 			sprintf('.PHONY : bisulfite_compare_%s', i),
-			sprintf('bisulfite_compare_%s : $(BISULFITE_COMPARE_%s_PREREQS)', i, i),
+			sprintf('bisulfite_compare_%s : bisulfite_align $(BISULFITE_COMPARE_%s_PREREQS)', i, i),
 			'',
 '# Rule for methylSig input
 .INTERMEDIATE : $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_methylSig.txt

--- a/scripts/sub_init_bis_compare.R
+++ b/scripts/sub_init_bis_compare.R
@@ -70,7 +70,7 @@ if(bool_bis_comp) {
 		msig_results = sprintf('$(DIR_BIS_MSIG)/%s_$(OPT_DM_TYPE)_methylSig.txt', var_comparison)
 		msig_tmp_results = sprintf('$(DIR_BIS_MSIG)/%s_$(OPT_DM_TYPE)_methylSig_tmp.txt', var_comparison)
 		annotatr_bed = sprintf('$(DIR_BIS_MSIG)/%s_$(OPT_DM_TYPE)_methylSig_for_annotatr.txt', var_comparison)
-		annotatr_png = sprintf('$(DIR_SUM_FIGURES)/%s_$(OPT_DM_TYPE)_methylSig_counts.png', var_comparison)
+		annotatr_rdata = sprintf('$(DIR_RDATA)/%s_$(OPT_DM_TYPE)_methylSig_annotatr_analysis.RData', var_comparison)
 		msig_bigwig = sprintf('$(DIR_TRACK)/%s_methylSig.bw', var_comparison)
 
 		########################################################################
@@ -80,7 +80,7 @@ if(bool_bis_comp) {
 		make_vars_bis_compare = c(
 			'################################################################################',
 			'# Workflow for bisulfite_compare',
-			sprintf('BISULFITE_COMPARE_%s_PREREQS := %s %s %s', i, msig_results, msig_bigwig, annotatr_png),
+			sprintf('BISULFITE_COMPARE_%s_PREREQS := %s %s %s', i, msig_results, msig_bigwig, annotatr_rdata),
 			sprintf('BISULFITE_COMPARE_%s_CYTFILES := %s', i, var_cytfiles),
 			sprintf('BISULFITE_COMPARE_%s_SAMPLEIDS := %s', i, var_sampleids),
 			sprintf('BISULFITE_COMPARE_%s_TREATMENT := %s', i, var_treatment),
@@ -111,7 +111,7 @@ $(DIR_BIS_BISMARK)/%_trimmed_bismark_bt2.CpG_report_for_methylSig.txt : $(DIR_BI
 			sprintf('%s : %s', annotatr_bed, msig_results),
 			'	$(PATH_TO_AWK) -v FDR=$(OPT_MSIG_DM_FDR_THRESHOLD) -v DIFF=$(OPT_MSIG_DM_DIFF_THRESHOLD) -f ../../scripts/methylSig_to_annotatr.awk $< > $@',
 			'',
-			sprintf('%s : %s', annotatr_png, annotatr_bed),
+			sprintf('%s : %s', annotatr_rdata, annotatr_bed),
 			'	$(PATH_TO_R) ../../scripts/annotatr_bisulfite.R --file $< --genome $(GENOME)',
 			'',
 			sprintf('%s : %s', msig_bigwig, msig_tmp_results),

--- a/scripts/sub_init_bis_compare.R
+++ b/scripts/sub_init_bis_compare.R
@@ -85,7 +85,7 @@ if(bool_bis_comp) {
 			sprintf('BISULFITE_COMPARE_%s_SAMPLEIDS := %s', i, var_sampleids),
 			sprintf('BISULFITE_COMPARE_%s_TREATMENT := %s', i, var_treatment),
 			sprintf('BISULFITE_COMPARE_%s_COMPARISON := %s_$(OPT_DM_TYPE)_methylSig', i, var_comparison),
-			sprintf('BISULFITE_COMPARE_%s_CLEAN_TMP := %s %s', msig_tmp_results, annotatr_bed))
+			sprintf('BISULFITE_COMPARE_%s_CLEAN_TMP := %s %s', i, msig_tmp_results, annotatr_bed))
 		cat(make_vars_bis_compare, file = file_make, sep='\n', append=T)
 
 		########################################################################

--- a/scripts/sub_init_clean.R
+++ b/scripts/sub_init_clean.R
@@ -1,5 +1,4 @@
 make_clean_tmp_rule = '.PHONY : clean_tmp
-clean_tmp :
-	clean_bisulfite_align_tmp clean_bisulfite_compare_tmp clean_pulldown_sample_tmp clean_pulldown_compare_tmp clean_sample_classification_tmp clean_compare_classification_tmp'
+clean_tmp : clean_bisulfite_align_tmp clean_bisulfite_compare_tmp clean_pulldown_sample_tmp clean_pulldown_compare_tmp clean_sample_classification_tmp clean_compare_classification_tmp'
 
 cat(make_clean_tmp_rule, file = file_make, sep = '\n', append = TRUE)

--- a/scripts/sub_init_clean.R
+++ b/scripts/sub_init_clean.R
@@ -1,0 +1,5 @@
+make_clean_tmp_rule = '.PHONY : clean_tmp
+clean_tmp :
+	clean_bisulfite_align_tmp clean_bisulfite_compare_tmp clean_pulldown_sample_tmp clean_pulldown_compare_tmp clean_sample_classification_tmp clean_compare_classification_tmp'
+
+cat(make_clean_tmp_rule, file = file_make, sep = '\n', append = TRUE)

--- a/scripts/sub_init_clean.R
+++ b/scripts/sub_init_clean.R
@@ -1,4 +1,24 @@
-make_clean_tmp_rule = '.PHONY : clean_tmp
-clean_tmp : clean_bisulfite_align_tmp clean_bisulfite_compare_tmp clean_pulldown_sample_tmp clean_pulldown_compare_tmp clean_sample_classification_tmp clean_compare_classification_tmp'
+################################################################################
+# MAKEFILE: clean rules
+
+clean_str = ''
+if(bool_bis_samp) {
+	clean_str = paste(clean_str, 'clean_bisulfite_align_tmp')
+}
+
+if(bool_pull_samp) {
+	clean_str = paste(clean_str, 'clean_pulldown_sample_tmp', 'clean_sample_classification_tmp')
+}
+
+if(bool_bis_comp) {
+	clean_str = paste(clean_str, 'clean_bisulfite_compare_tmp', 'clean_compare_classification_tmp')
+}
+
+if(bool_pull_comp) {
+	clean_str = paste(clean_str, 'clean_pulldown_compare_tmp')
+}
+
+make_clean_tmp_rule = sprintf('.PHONY : clean_tmp
+clean_tmp : %s', clean_str)
 
 cat(make_clean_tmp_rule, file = file_make, sep = '\n', append = TRUE)

--- a/scripts/sub_init_clean.R
+++ b/scripts/sub_init_clean.R
@@ -7,15 +7,23 @@ if(bool_bis_samp) {
 }
 
 if(bool_pull_samp) {
-	clean_str = paste(clean_str, 'clean_pulldown_sample_tmp', 'clean_sample_classification_tmp')
+	clean_str = paste(clean_str, 'clean_pulldown_sample_tmp')
+}
+
+if(bool_bis_samp || bool_pull_samp) {
+	clean_str = paste(clean_str, 'clean_sample_classification_tmp')
 }
 
 if(bool_bis_comp) {
-	clean_str = paste(clean_str, 'clean_bisulfite_compare_tmp', 'clean_compare_classification_tmp')
+	clean_str = paste(clean_str, 'clean_bisulfite_compare_tmp')
 }
 
 if(bool_pull_comp) {
 	clean_str = paste(clean_str, 'clean_pulldown_compare_tmp')
+}
+
+if(bool_bis_comp || bool_pull_comp) {
+	clean_str = paste(clean_str, 'clean_compare_classification_tmp')
 }
 
 make_clean_tmp_rule = sprintf('.PHONY : clean_tmp

--- a/scripts/sub_init_compare_class.R
+++ b/scripts/sub_init_compare_class.R
@@ -147,8 +147,7 @@ if(bool_bis_comp && bool_pull_comp) {
 make_rule_class_compare = sprintf('
 # Master rule
 .PHONY : compare_classification
-compare_classification : pulldown_align pulldown_compare bisulfite_align bisulfite_compare
-		$(patsubst %%,$(DIR_TRACK)/%%_compare_classification.bb,$(COMPARE_CLASS_PREFIXES)) \\
+compare_classification : $(patsubst %%,$(DIR_TRACK)/%%_compare_classification.bb,$(COMPARE_CLASS_PREFIXES)) \\
 		$(patsubst %%,$(DIR_SUM_FIGURES)/%%_compare_class_counts.png,$(COMPARE_CLASS_PREFIXES)) \\
 		$(patsubst %%,$(DIR_CLASS_COMPARE)/%%_compare_classification.bed,$(COMPARE_CLASS_PREFIXES))
 

--- a/scripts/sub_init_compare_class.R
+++ b/scripts/sub_init_compare_class.R
@@ -182,22 +182,22 @@ cat(make_rule_class_compare, file = file_make, sep = '\n', append = TRUE)
 
 #######################################
 # PBS script
-# bisulfite_compare_q = c(
-# 	'#!/bin/bash',
-# 	'#### Begin PBS preamble',
-# 	'#PBS -N class_compare',
-# 	'#PBS -l procs=4,mem=32gb,walltime=6:00:00',
-# 	'#PBS -A sartor_lab',
-# 	'#PBS -q first',
-# 	'#PBS -M rcavalca@umich.edu',
-# 	'#PBS -m abe',
-# 	'#PBS -j oe',
-# 	'#PBS -V',
-# 	'#### End PBS preamble',
-# 	'# Put your job commands after this line',
-# 	sprintf('cd ~/latte/mint/projects/%s/',project),
-# 	'make -j 4 compare_classification')
-# cat(bisulfite_compare_q, file=sprintf('projects/%s/pbs_jobs/classify_compare.q', project), sep='\n')
+bisulfite_compare_q = c(
+	'#!/bin/bash',
+	'#### Begin PBS preamble',
+	'#PBS -N class_compare',
+	'#PBS -l nodes=1:ppn=4,walltime=24:00:00,pmem=16gb',
+	'#PBS -A sartor_lab',
+	'#PBS -q first',
+	'#PBS -M rcavalca@umich.edu',
+	'#PBS -m abe',
+	'#PBS -j oe',
+	'#PBS -V',
+	'#### End PBS preamble',
+	'# Put your job commands after this line',
+	sprintf('cd ~/latte/mint/projects/%s/',project),
+	'make -j 4 compare_classification')
+cat(bisulfite_compare_q, file=sprintf('projects/%s/pbs_jobs/classify_compare.q', project), sep='\n')
 
 for(comparison in unique(comparisons$humanID)) {
 	# trackDb.txt entry for comparison classification

--- a/scripts/sub_init_compare_class.R
+++ b/scripts/sub_init_compare_class.R
@@ -148,7 +148,7 @@ make_rule_class_compare = sprintf('
 # Master rule
 .PHONY : compare_classification
 compare_classification : $(patsubst %%,$(DIR_TRACK)/%%_compare_classification.bb,$(COMPARE_CLASS_PREFIXES)) \\
-		$(patsubst %%,$(DIR_SUM_FIGURES)/%%_compare_class_counts.png,$(COMPARE_CLASS_PREFIXES)) \\
+		$(patsubst %%,$(DIR_RDATA)/%%_compare_class_annotatr_analysis.RData,$(COMPARE_CLASS_PREFIXES)) \\
 		$(patsubst %%,$(DIR_CLASS_COMPARE)/%%_compare_classification.bed,$(COMPARE_CLASS_PREFIXES))
 
 # Rule for compare classification bigBed
@@ -156,7 +156,7 @@ $(DIR_TRACK)/%%_compare_classification.bb : $(DIR_CLASS_COMPARE)/%%_compare_clas
 	$(PATH_TO_BDG2BB) $^ $(CHROM_PATH) $@
 
 # Rule for annotatr of compare classification
-$(DIR_SUM_FIGURES)/%%_compare_class_counts.png : $(DIR_CLASS_COMPARE)/%%_compare_class_for_annotatr.txt
+$(DIR_RDATA)/%%_compare_class_annotatr_analysis.RData : $(DIR_CLASS_COMPARE)/%%_compare_class_for_annotatr.txt
 	$(PATH_TO_R) ../../scripts/annotatr_classification.R --file $< --genome $(GENOME)
 
 .INTERMEDIATE : $(DIR_CLASS_COMPARE)/%%_compare_class_for_annotatr.txt

--- a/scripts/sub_init_compare_class.R
+++ b/scripts/sub_init_compare_class.R
@@ -174,8 +174,8 @@ $(DIR_CLASS_COMPARE)/%%_compare_class_for_annotatr.txt : $(DIR_CLASS_COMPARE)/%%
 # Clean temporary files that make does not clean up
 %s
 
-.PHONY : compare_classification_clean_tmp
-compare_classification_clean_tmp :
+.PHONY : clean_compare_classification_tmp
+clean_compare_classification_tmp :
 	rm -f $(COMPARE_CLASS_CLEAN_TMP)',
 	compare_class_target, class_script, rule1, rule2, compare_class_tmps)
 cat(make_rule_class_compare, file = file_make, sep = '\n', append = TRUE)

--- a/scripts/sub_init_compare_class.R
+++ b/scripts/sub_init_compare_class.R
@@ -80,6 +80,14 @@ cat(make_var_compare_class_prefix, file = file_make, sep = '\n', append = TRUE)
 
 # The compare class type depends on the type of compares present
 if(bool_bis_comp && bool_pull_comp) {
+	compare_class_tmps = '$(COMPARE_CLASS_CLEAN_TMP) := $(patsubst %,$(DIR_BIS_MSIG)/%_mc_hmc_bisulfite_DMup.txt,$(COMPARE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_BIS_MSIG)/%_mc_hmc_bisulfite_DMdown.txt,$(COMPARE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_BIS_MSIG)/%_mc_hmc_bisulfite_noDM_signal.txt,$(COMPARE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_BIS_MSIG)/%_mc_hmc_bisulfite_noDM_nosignal.txt,$(COMPARE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_PULL_PEPR)/%_hmc_pulldown_DMup.txt,$(COMPARE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_PULL_PEPR)/%_hmc_pulldown_DMdown.txt,$(COMPARE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_PULL_PEPR)/%_hmc_pulldown_noDM_signal.txt,$(COMPARE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_PULL_PEPR)/%_hmc_pulldown_noDM_nosignal.txt,$(COMPARE_CLASS_PREFIXES)) \\'
 	compare_class_target = '$(DIR_CLASS_COMPARE)/%_compare_classification.bed : 	$(DIR_BIS_MSIG)/%_mc_hmc_bisulfite_DMup.txt \\
 								$(DIR_BIS_MSIG)/%_mc_hmc_bisulfite_DMdown.txt \\
 								$(DIR_BIS_MSIG)/%_mc_hmc_bisulfite_noDM_signal.txt \\
@@ -95,6 +103,14 @@ if(bool_bis_comp && bool_pull_comp) {
 	############################################################
 	# NOTE: THIS IS NOT EXPLICITLY SUPPORTED RIGHT NOW
 	############################################################
+	compare_class_tmps = '$(COMPARE_CLASS_CLEAN_TMP) := $(patsubst %,$(DIR_BIS_MSIG)/%_mc_bisulfite_DMup.txt,$(COMPARE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_BIS_MSIG)/%_mc_bisulfite_DMdown.txt,$(COMPARE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_BIS_MSIG)/%_mc_bisulfite_noDM_signal.txt,$(COMPARE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_BIS_MSIG)/%_mc_bisulfite_noDM_nosignal.txt,$(COMPARE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_BIS_MSIG)/%_hmc_bisulfite_DMup.txt,$(COMPARE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_BIS_MSIG)/%_hmc_bisulfite_DMdown.txt,$(COMPARE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_BIS_MSIG)/%_hmc_bisulfite_noDM_signal.txt,$(COMPARE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_BIS_MSIG)/%_hmc_bisulfite_noDM_nosignal.txt,$(COMPARE_CLASS_PREFIXES)) \\'
 	compare_class_target = '$(DIR_CLASS_COMPARE)/%_compare_classification.bed : 	$(DIR_BIS_MSIG)/%_mc_bisulfite_DMup.txt \\
 								$(DIR_BIS_MSIG)/%_mc_bisulfite_DMdown.txt \\
 								$(DIR_BIS_MSIG)/%_mc_bisulfite_noDM_signal.txt \\
@@ -107,6 +123,14 @@ if(bool_bis_comp && bool_pull_comp) {
 	rule2 = ''
 	class_script = '../../scripts/classify_compare.sh'
 } else if (!bool_bis_comp && bool_pull_comp) {
+	compare_class_tmps = '$(COMPARE_CLASS_CLEAN_TMP) := $(patsubst %,$(DIR_PULL_PEPR)/%_mc_pulldown_DMup.txt,$(COMPARE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_PULL_PEPR)/%_mc_pulldown_DMdown.txt,$(COMPARE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_PULL_PEPR)/%_mc_pulldown_noDM_signal.txt,$(COMPARE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_PULL_PEPR)/%_mc_pulldown_noDM_nosignal.txt,$(COMPARE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_PULL_PEPR)/%_hmc_pulldown_DMup.txt,$(COMPARE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_PULL_PEPR)/%_hmc_pulldown_DMdown.txt,$(COMPARE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_PULL_PEPR)/%_hmc_pulldown_noDM_signal.txt,$(COMPARE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_PULL_PEPR)/%_hmc_pulldown_noDM_nosignal.txt,$(COMPARE_CLASS_PREFIXES)) \\'
 	compare_class_target = '$(DIR_CLASS_COMPARE)/%_compare_classification.bed : 	$(DIR_PULL_PEPR)/%_mc_pulldown_DMup.txt \\
 								$(DIR_PULL_PEPR)/%_mc_pulldown_DMdown.txt \\
 								$(DIR_PULL_PEPR)/%_mc_pulldown_noDM_signal.txt \\
@@ -139,19 +163,21 @@ $(DIR_SUM_FIGURES)/%%_compare_class_counts.png : $(DIR_CLASS_COMPARE)/%%_compare
 $(DIR_CLASS_COMPARE)/%%_compare_class_for_annotatr.txt : $(DIR_CLASS_COMPARE)/%%_compare_classification.bed
 	cut -f 1-4 $< > $@
 
-# NOTE: There is a known bug in make that incorrectly determines implicit intermediate
-# files when they occur in a list of multiple targets and prerequisites.
-# https://savannah.gnu.org/bugs/index.php?32042
-# The easiest workaround is to make them precious and remove them
-
 # Classification BED
 .PRECIOUS : $(DIR_CLASS_COMPARE)/%%_compare_classification.bed
 %s
 	bash %s $(PATH_TO_BEDTOOLS) $(PATH_TO_AWK) $(CHROM_PATH) $@ $^
 
 %s
-%s',
-	compare_class_target, class_script, rule1, rule2)
+%s
+
+# Clean temporary files that make does not clean up
+%s
+
+.PHONY : compare_classification_clean_tmp
+compare_classification_clean_tmp :
+	rm -f $(COMPARE_CLASS_CLEAN_TMP)',
+	compare_class_target, class_script, rule1, rule2, compare_class_tmps)
 cat(make_rule_class_compare, file = file_make, sep = '\n', append = TRUE)
 
 #######################################

--- a/scripts/sub_init_compare_class.R
+++ b/scripts/sub_init_compare_class.R
@@ -147,7 +147,8 @@ if(bool_bis_comp && bool_pull_comp) {
 make_rule_class_compare = sprintf('
 # Master rule
 .PHONY : compare_classification
-compare_classification : 	$(patsubst %%,$(DIR_TRACK)/%%_compare_classification.bb,$(COMPARE_CLASS_PREFIXES)) \\
+compare_classification : pulldown_align pulldown_compare bisulfite_align bisulfite_compare
+		$(patsubst %%,$(DIR_TRACK)/%%_compare_classification.bb,$(COMPARE_CLASS_PREFIXES)) \\
 		$(patsubst %%,$(DIR_SUM_FIGURES)/%%_compare_class_counts.png,$(COMPARE_CLASS_PREFIXES)) \\
 		$(patsubst %%,$(DIR_CLASS_COMPARE)/%%_compare_classification.bed,$(COMPARE_CLASS_PREFIXES))
 

--- a/scripts/sub_init_compare_class.R
+++ b/scripts/sub_init_compare_class.R
@@ -80,7 +80,7 @@ cat(make_var_compare_class_prefix, file = file_make, sep = '\n', append = TRUE)
 
 # The compare class type depends on the type of compares present
 if(bool_bis_comp && bool_pull_comp) {
-	compare_class_tmps = '$(COMPARE_CLASS_CLEAN_TMP) := $(patsubst %,$(DIR_BIS_MSIG)/%_mc_hmc_bisulfite_DMup.txt,$(COMPARE_CLASS_PREFIXES)) \\
+	compare_class_tmps = 'COMPARE_CLASS_CLEAN_TMP := $(patsubst %,$(DIR_BIS_MSIG)/%_mc_hmc_bisulfite_DMup.txt,$(COMPARE_CLASS_PREFIXES)) \\
 								$(patsubst %,$(DIR_BIS_MSIG)/%_mc_hmc_bisulfite_DMdown.txt,$(COMPARE_CLASS_PREFIXES)) \\
 								$(patsubst %,$(DIR_BIS_MSIG)/%_mc_hmc_bisulfite_noDM_signal.txt,$(COMPARE_CLASS_PREFIXES)) \\
 								$(patsubst %,$(DIR_BIS_MSIG)/%_mc_hmc_bisulfite_noDM_nosignal.txt,$(COMPARE_CLASS_PREFIXES)) \\
@@ -103,7 +103,7 @@ if(bool_bis_comp && bool_pull_comp) {
 	############################################################
 	# NOTE: THIS IS NOT EXPLICITLY SUPPORTED RIGHT NOW
 	############################################################
-	compare_class_tmps = '$(COMPARE_CLASS_CLEAN_TMP) := $(patsubst %,$(DIR_BIS_MSIG)/%_mc_bisulfite_DMup.txt,$(COMPARE_CLASS_PREFIXES)) \\
+	compare_class_tmps = 'COMPARE_CLASS_CLEAN_TMP := $(patsubst %,$(DIR_BIS_MSIG)/%_mc_bisulfite_DMup.txt,$(COMPARE_CLASS_PREFIXES)) \\
 								$(patsubst %,$(DIR_BIS_MSIG)/%_mc_bisulfite_DMdown.txt,$(COMPARE_CLASS_PREFIXES)) \\
 								$(patsubst %,$(DIR_BIS_MSIG)/%_mc_bisulfite_noDM_signal.txt,$(COMPARE_CLASS_PREFIXES)) \\
 								$(patsubst %,$(DIR_BIS_MSIG)/%_mc_bisulfite_noDM_nosignal.txt,$(COMPARE_CLASS_PREFIXES)) \\
@@ -123,7 +123,7 @@ if(bool_bis_comp && bool_pull_comp) {
 	rule2 = ''
 	class_script = '../../scripts/classify_compare.sh'
 } else if (!bool_bis_comp && bool_pull_comp) {
-	compare_class_tmps = '$(COMPARE_CLASS_CLEAN_TMP) := $(patsubst %,$(DIR_PULL_PEPR)/%_mc_pulldown_DMup.txt,$(COMPARE_CLASS_PREFIXES)) \\
+	compare_class_tmps = 'COMPARE_CLASS_CLEAN_TMP := $(patsubst %,$(DIR_PULL_PEPR)/%_mc_pulldown_DMup.txt,$(COMPARE_CLASS_PREFIXES)) \\
 								$(patsubst %,$(DIR_PULL_PEPR)/%_mc_pulldown_DMdown.txt,$(COMPARE_CLASS_PREFIXES)) \\
 								$(patsubst %,$(DIR_PULL_PEPR)/%_mc_pulldown_noDM_signal.txt,$(COMPARE_CLASS_PREFIXES)) \\
 								$(patsubst %,$(DIR_PULL_PEPR)/%_mc_pulldown_noDM_nosignal.txt,$(COMPARE_CLASS_PREFIXES)) \\

--- a/scripts/sub_init_pull_align.R
+++ b/scripts/sub_init_pull_align.R
@@ -9,7 +9,6 @@ make_var_pull_align_prefix = sprintf('
 PULLDOWN_ALIGN_PREFIXES := %s', paste(pulldown_samples$fullHumanID, collapse=' '))
 
 make_var_pull_align = 'PULLDOWN_ALIGN_PREREQS :=  $(patsubst %,$(DIR_TRACK)/%_coverage.bw,$(PULLDOWN_ALIGN_PREFIXES)) \\
-					$(patsubst %,$(DIR_PULL_COVERAGES)/%_coverage.bdg,$(PULLDOWN_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_PULL_COVERAGES)/%_merged_coverage.bdg,$(PULLDOWN_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_PULL_BOWTIE2)/%_trimmed.fq.gz_aligned.bam,$(PULLDOWN_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_PULL_TRIM_FASTQCS)/%_trimmed_fastqc.zip,$(PULLDOWN_ALIGN_PREFIXES)) \\
@@ -26,6 +25,7 @@ $(DIR_TRACK)/%_coverage.bw : $(DIR_PULL_COVERAGES)/%_coverage.bdg
 	$(PATH_TO_BDG2BW) $< $(CHROM_PATH) $@
 
 # Rule for coverage bedGraph
+.INTERMEDIATE : $(DIR_PULL_COVERAGES)/%_coverage.bdg
 $(DIR_PULL_COVERAGES)/%_coverage.bdg : $(DIR_PULL_BOWTIE2)/%_trimmed.fq.gz_aligned.bam
 	$(PATH_TO_BEDTOOLS) genomecov -bg -g $(CHROM_PATH) -ibam $< | sort -T . -k1,1 -k2,2n > $@
 

--- a/scripts/sub_init_pull_align.R
+++ b/scripts/sub_init_pull_align.R
@@ -59,22 +59,22 @@ cat(make_rule_pull_align, file = file_make, sep = '\n', append = TRUE)
 
 #######################################
 # PBS script
-# pulldown_align_q = c(
-# 	'#!/bin/bash',
-# 	'#### Begin PBS preamble',
-# 	'#PBS -N pull_align',
-# 	'#PBS -l procs=4,mem=32gb,walltime=6:00:00',
-# 	'#PBS -A sartor_lab',
-# 	'#PBS -q first',
-# 	'#PBS -M rcavalca@umich.edu',
-# 	'#PBS -m abe',
-# 	'#PBS -j oe',
-# 	'#PBS -V',
-# 	'#### End PBS preamble',
-# 	'# Put your job commands after this line',
-# 	sprintf('cd ~/latte/mint/projects/%s/',project),
-# 	'make -j 4 pulldown_align')
-# cat(pulldown_align_q, file=sprintf('projects/%s/pbs_jobs/pulldown_align.q', project), sep='\n')
+pulldown_align_q = c(
+	'#!/bin/bash',
+	'#### Begin PBS preamble',
+	'#PBS -N pull_align',
+	'#PBS -l nodes=1:ppn=8,walltime=24:00:00,pmem=16gb',
+	'#PBS -A sartor_lab',
+	'#PBS -q first',
+	'#PBS -M rcavalca@umich.edu',
+	'#PBS -m abe',
+	'#PBS -j oe',
+	'#PBS -V',
+	'#### End PBS preamble',
+	'# Put your job commands after this line',
+	sprintf('cd ~/latte/mint/projects/%s/',project),
+	'make -j 8 pulldown_align')
+cat(pulldown_align_q, file=sprintf('projects/%s/pbs_jobs/pulldown_align.q', project), sep='\n')
 
 for(i in 1:nrow(pulldown_samples)) {
 	# trackDb.txt entry for chip/input pulldown coverages

--- a/scripts/sub_init_pull_align.R
+++ b/scripts/sub_init_pull_align.R
@@ -9,7 +9,7 @@ make_var_pull_align_prefix = sprintf('
 PULLDOWN_ALIGN_PREFIXES := %s', paste(pulldown_samples$fullHumanID, collapse=' '))
 
 make_var_pull_align = 'PULLDOWN_ALIGN_PREREQS :=  $(patsubst %,$(DIR_TRACK)/%_coverage.bw,$(PULLDOWN_ALIGN_PREFIXES)) \\
-					$(patsubst %,$(DIR_PULL_COVERAGES)/%_merged_coverage.bdg,$(PULLDOWN_ALIGN_PREFIXES)) \\
+					$(patsubst %,$(DIR_PULL_COVERAGES)/%_coverage_merged.bdg,$(PULLDOWN_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_PULL_BOWTIE2)/%_trimmed.fq.gz_aligned.bam,$(PULLDOWN_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_PULL_TRIM_FASTQCS)/%_trimmed_fastqc.zip,$(PULLDOWN_ALIGN_PREFIXES)) \\
 					$(patsubst %,$(DIR_PULL_TRIM_FASTQS)/%_trimmed.fq.gz,$(PULLDOWN_ALIGN_PREFIXES)) \\
@@ -31,7 +31,7 @@ $(DIR_PULL_COVERAGES)/%_coverage.bdg : $(DIR_PULL_BOWTIE2)/%_trimmed.fq.gz_align
 
 # Rule for merged coverage BED
 # For use in signal BEDs downstream
-$(DIR_PULL_COVERAGES)/%_merged_coverage.bdg : $(DIR_PULL_COVERAGES)/%_coverage.bdg
+$(DIR_PULL_COVERAGES)/%_coverage_merged.bdg : $(DIR_PULL_COVERAGES)/%_coverage.bdg
 	$(PATH_TO_BEDTOOLS) merge -d 20 -i $< | sort -T . -k1,1 -k2,2n > $@
 
 # Rule for bowtie2 alignment

--- a/scripts/sub_init_pull_align.R
+++ b/scripts/sub_init_pull_align.R
@@ -36,7 +36,7 @@ $(DIR_PULL_COVERAGES)/%_merged_coverage.bdg : $(DIR_PULL_COVERAGES)/%_coverage.b
 
 # Rule for bowtie2 alignment
 $(DIR_PULL_BOWTIE2)/%_trimmed.fq.gz_aligned.bam : $(DIR_PULL_TRIM_FASTQS)/%_trimmed.fq.gz $(DIR_PULL_TRIM_FASTQCS)/%_trimmed_fastqc.zip
-	$(PATH_TO_BOWTIE2) $(OPTS_BOWTIE2) $< | $(PATH_TO_SAMTOOLS) view -bS - > $@
+	$(PATH_TO_BOWTIE2) $(OPTS_BOWTIE2) $< 2> $(@D)/$(@F).txt | $(PATH_TO_SAMTOOLS) view -bS - > $@
 	$(PATH_TO_SAMTOOLS) sort $@ $(patsubst %.bam,%,$@)
 	$(PATH_TO_SAMTOOLS) index $@
 

--- a/scripts/sub_init_pull_compare.R
+++ b/scripts/sub_init_pull_compare.R
@@ -79,8 +79,8 @@ if(bool_pull_comp) {
 		var_chip2 = paste(sprintf('$(DIR_PULL_BOWTIE2)/%s_trimmed.fq.gz_aligned.bam', groupB$fullHumanID), sep='', collapse=',')
 
 		# For the prerequisites in the make rule
-		var_merged_input1_pre = paste(sprintf('$(DIR_PULL_COVERAGES)/%s_merged_coverage.bdg', inputGroupA$fullHumanID), sep='', collapse=' ')
-		var_merged_input2_pre = paste(sprintf('$(DIR_PULL_COVERAGES)/%s_merged_coverage.bdg', inputGroupB$fullHumanID), sep='', collapse=' ')
+		var_merged_input1_pre = paste(sprintf('$(DIR_PULL_COVERAGES)/%s_coverage_merged.bdg', inputGroupA$fullHumanID), sep='', collapse=' ')
+		var_merged_input2_pre = paste(sprintf('$(DIR_PULL_COVERAGES)/%s_coverage_merged.bdg', inputGroupB$fullHumanID), sep='', collapse=' ')
 		var_input1_pre = paste(sprintf('$(DIR_PULL_BOWTIE2)/%s_trimmed.fq.gz_aligned.bam', inputGroupA$fullHumanID), sep='', collapse=' ')
 		var_input2_pre = paste(sprintf('$(DIR_PULL_BOWTIE2)/%s_trimmed.fq.gz_aligned.bam', inputGroupB$fullHumanID), sep='', collapse=' ')
 		var_chip1_pre = paste(sprintf('$(DIR_PULL_BOWTIE2)/%s_trimmed.fq.gz_aligned.bam', groupA$fullHumanID), sep='', collapse=' ')

--- a/scripts/sub_init_pull_compare.R
+++ b/scripts/sub_init_pull_compare.R
@@ -144,7 +144,7 @@ if(bool_pull_comp) {
 		########################################################################
 		# OPTS for config.mk
 		config_pull_compare = sprintf(
-			'OPTS_PEPR_%s = --file-format=bam --peaktype=sharp --diff --threshold=1e-03 --num-processors=1
+			'OPTS_PEPR_%s = --file-format=bam --peaktype=sharp --diff --threshold=1e-05 --num-processors=1
 			',
 			var_name)
 		cat(config_pull_compare, file = file_config, sep='\n', append=T)

--- a/scripts/sub_init_pull_compare.R
+++ b/scripts/sub_init_pull_compare.R
@@ -183,21 +183,21 @@ if(bool_pull_comp) {
 
 	#######################################
 	# PBS script
-	# pulldown_compare_q = c(
-	# 	'#!/bin/bash',
-	# 	'#### Begin PBS preamble',
-	# 	'#PBS -N pull_compare',
-	# 	'#PBS -l procs=1,mem=32gb,walltime=6:00:00',
-	# 	'#PBS -A sartor_lab',
-	# 	'#PBS -q first',
-	# 	'#PBS -M rcavalca@umich.edu',
-	# 	'#PBS -m abe',
-	# 	'#PBS -j oe',
-	# 	'#PBS -V',
-	# 	'#### End PBS preamble',
-	# 	'# Put your job commands after this line',
-	# 	sprintf('cd ~/latte/mint/projects/%s/',project),
-	# 	'make pulldown_compare')
-	# cat(pulldown_compare_q, file=sprintf('projects/%s/pbs_jobs/pulldown_compare.q', project), sep='\n')
+	pulldown_compare_q = c(
+		'#!/bin/bash',
+		'#### Begin PBS preamble',
+		'#PBS -N pull_compare',
+		'#PBS -l nodes=1:ppn=8,walltime=24:00:00,pmem=8gb',
+		'#PBS -A sartor_lab',
+		'#PBS -q first',
+		'#PBS -M rcavalca@umich.edu',
+		'#PBS -m abe',
+		'#PBS -j oe',
+		'#PBS -V',
+		'#### End PBS preamble',
+		'# Put your job commands after this line',
+		sprintf('cd ~/latte/mint/projects/%s/',project),
+		'make pulldown_compare')
+	cat(pulldown_compare_q, file=sprintf('projects/%s/pbs_jobs/pulldown_compare.q', project), sep='\n')
 
 }

--- a/scripts/sub_init_pull_compare.R
+++ b/scripts/sub_init_pull_compare.R
@@ -137,15 +137,15 @@ if(bool_pull_comp) {
 			sprintf('%s : %s', bigbed, combined_bed),
 			'	$(PATH_TO_BDG2BB) $^ $(CHROM_PATH) $@',
 			'',
-			sprintf('.PHONY : pulldown_compare_clean_tmp_%s', i),
-			sprintf('pulldown_compare_clean_tmp_%s :
+			sprintf('.PHONY : clean_pulldown_compare_tmp_%s', i),
+			sprintf('clean_pulldown_compare_tmp_%s :
 				rm -f $(PULLDOWN_COMPARE_%s_CLEAN_TMP)', i, i),
 			'')
 		cat(make_rule_pull_compare, file = file_make, sep='\n', append=T)
 
 		# Track the number of pulldown compares
 		pulldown_compares = c(pulldown_compares, sprintf('pulldown_compare_%s', i))
-		pulldown_clean_tmps = c(pulldown_clean_tmps, sprintf('pulldown_compare_clean_tmp_%s', i))
+		pulldown_clean_tmps = c(pulldown_clean_tmps, sprintf('clean_pulldown_compare_tmp_%s', i))
 
 		########################################################################
 		# OPTS for config.mk

--- a/scripts/sub_init_pull_compare.R
+++ b/scripts/sub_init_pull_compare.R
@@ -4,7 +4,7 @@
 if(bool_pull_comp) {
 	# Keep track of the compares for the master make rules
 	pulldown_compares = c()
-
+	pulldown_clean_tmps = c()
 	for(i in 1:nrow(pulldown_comparisons)) {
 		# Establish row variables
 		projectID = pulldown_comparisons[i,'projectID']
@@ -108,7 +108,8 @@ if(bool_pull_comp) {
 			sprintf('PULLDOWN_COMPARE_%s_INPUT2 := %s', i, var_input2),
 			sprintf('PULLDOWN_COMPARE_%s_CHIP1 := %s', i, var_chip1),
 			sprintf('PULLDOWN_COMPARE_%s_CHIP2 := %s', i, var_chip2),
-			sprintf('PULLDOWN_COMPARE_%s_NAME := %s', i, var_name))
+			sprintf('PULLDOWN_COMPARE_%s_NAME := %s', i, var_name),
+			sprintf('PULLDOWN_COMPARE_%s_CLEAN_TMP := %s', annotatr_bed))
 		cat(make_var_pull_compare, file = file_make, sep='\n', append=T)
 
 		# Write the pulldown_compare rule for this comparison
@@ -135,11 +136,16 @@ if(bool_pull_comp) {
 			'',
 			sprintf('%s : %s', bigbed, combined_bed),
 			'	$(PATH_TO_BDG2BB) $^ $(CHROM_PATH) $@',
+			'',
+			sprintf('.PHONY : pulldown_compare_clean_tmp_%s', i),
+			sprintf('pulldown_compare_clean_tmp_%s :
+				rm -f $(PULLDOWN_COMPARE_%s_CLEAN_TMP)', i, i),
 			'')
 		cat(make_rule_pull_compare, file = file_make, sep='\n', append=T)
 
 		# Track the number of pulldown compares
 		pulldown_compares = c(pulldown_compares, sprintf('pulldown_compare_%s', i))
+		pulldown_clean_tmps = c(pulldown_clean_tmps, sprintf('pulldown_compare_clean_tmp_%s', i))
 
 		########################################################################
 		# OPTS for config.mk
@@ -169,6 +175,9 @@ if(bool_pull_comp) {
 	make_rule_master_pull_compare = c(
 		'.PHONY : pulldown_compare',
 		sprintf('pulldown_compare : pulldown_align %s', paste(pulldown_compares, collapse=' ')),
+		'',
+		'.PHONY : clean_pulldown_compare_tmp',
+		sprintf('clean_pulldown_compare_tmp : %s', paste(pulldown_clean_tmps, collapse=' ')),
 		'')
 	cat(make_rule_master_pull_compare, file = file_make, sep='\n', append=T)
 

--- a/scripts/sub_init_pull_compare.R
+++ b/scripts/sub_init_pull_compare.R
@@ -115,7 +115,7 @@ if(bool_pull_comp) {
 		# Write the pulldown_compare rule for this comparison
 		make_rule_pull_compare = c(
 			sprintf('.PHONY : pulldown_compare_%s', i),
-			sprintf('pulldown_compare_%s : $(PULLDOWN_COMPARE_%s_PREREQS)', i, i),
+			sprintf('pulldown_compare_%s : pulldown_align $(PULLDOWN_COMPARE_%s_PREREQS)', i, i),
 			'',
 			sprintf('%s : %s %s %s %s', chip1_bed, var_input1_pre, var_input2_pre, var_chip1_pre, var_chip2_pre),
 			sprintf('	$(PATH_TO_PEPR) --input1=$(PULLDOWN_COMPARE_%s_INPUT1) --input2=$(PULLDOWN_COMPARE_%s_INPUT2) --chip1=$(PULLDOWN_COMPARE_%s_CHIP1) --chip2=$(PULLDOWN_COMPARE_%s_CHIP2) --name=$(PULLDOWN_COMPARE_%s_NAME) --output-directory=$(DIR_PULL_PEPR) $(OPTS_PEPR_%s)', i, i, i, i, i, var_name),

--- a/scripts/sub_init_pull_compare.R
+++ b/scripts/sub_init_pull_compare.R
@@ -93,7 +93,7 @@ if(bool_pull_comp) {
 		chip2_bed = sprintf('$(DIR_PULL_PEPR)/%s__PePr_chip2_peaks.bed', var_name)
 		combined_bed = sprintf('$(DIR_PULL_PEPR)/%s_PePr_combined.bed', var_name)
 		annotatr_bed = sprintf('$(DIR_PULL_PEPR)/%s_PePr_for_annotatr.txt', var_name)
-		annotatr_png = sprintf('$(DIR_SUM_FIGURES)/%s_PePr_counts.png', var_name)
+		annotatr_rdata = sprintf('$(DIR_RDATA)/%s_PePr_annotatr_analysis.RData', var_name)
 		bigbed = sprintf('$(DIR_TRACK)/%s_PePr_peaks.bb', var_name)
 
 		########################################################################
@@ -103,7 +103,7 @@ if(bool_pull_comp) {
 		make_var_pull_compare = c(
 			'################################################################################',
 			'# Workflow for pulldown_compare',
-			sprintf('PULLDOWN_COMPARE_%s_PREREQS := %s %s %s %s', i, chip1_bed, bigbed, input_signal, annotatr_png),
+			sprintf('PULLDOWN_COMPARE_%s_PREREQS := %s %s %s %s', i, chip1_bed, bigbed, input_signal, annotatr_rdata),
 			sprintf('PULLDOWN_COMPARE_%s_INPUT1 := %s', i, var_input1),
 			sprintf('PULLDOWN_COMPARE_%s_INPUT2 := %s', i, var_input2),
 			sprintf('PULLDOWN_COMPARE_%s_CHIP1 := %s', i, var_chip1),
@@ -128,7 +128,7 @@ if(bool_pull_comp) {
 			sprintf('%s : %s', annotatr_bed, combined_bed),
 			'	cut -f 1-4 $< > $@',
 			'',
-			sprintf('%s : %s', annotatr_png, annotatr_bed),
+			sprintf('%s : %s', annotatr_rdata, annotatr_bed),
 			'	$(PATH_TO_R) ../../scripts/annotatr_classification.R --file $< --genome $(GENOME)',
 			'',
 			sprintf('%s : %s %s', input_signal, var_merged_input1_pre, var_merged_input2_pre),

--- a/scripts/sub_init_pull_compare.R
+++ b/scripts/sub_init_pull_compare.R
@@ -89,8 +89,8 @@ if(bool_pull_comp) {
 
 		# Targets
 		input_signal = sprintf('$(DIR_PULL_PEPR)/%s_merged_signal.bed', var_name)
-		up_bed = sprintf('$(DIR_PULL_PEPR)/%s__PePr_chip1_peaks.bed', var_name)
-		down_bed = sprintf('$(DIR_PULL_PEPR)/%s__PePr_chip2_peaks.bed', var_name)
+		chip1_bed = sprintf('$(DIR_PULL_PEPR)/%s__PePr_chip1_peaks.bed', var_name)
+		chip2_bed = sprintf('$(DIR_PULL_PEPR)/%s__PePr_chip2_peaks.bed', var_name)
 		combined_bed = sprintf('$(DIR_PULL_PEPR)/%s_PePr_combined.bed', var_name)
 		annotatr_bed = sprintf('$(DIR_PULL_PEPR)/%s_PePr_for_annotatr.txt', var_name)
 		annotatr_png = sprintf('$(DIR_SUM_FIGURES)/%s_PePr_counts.png', var_name)
@@ -103,7 +103,7 @@ if(bool_pull_comp) {
 		make_var_pull_compare = c(
 			'################################################################################',
 			'# Workflow for pulldown_compare',
-			sprintf('PULLDOWN_COMPARE_%s_PREREQS := %s %s %s %s', i, up_bed, bigbed, input_signal, annotatr_png),
+			sprintf('PULLDOWN_COMPARE_%s_PREREQS := %s %s %s %s', i, chip1_bed, bigbed, input_signal, annotatr_png),
 			sprintf('PULLDOWN_COMPARE_%s_INPUT1 := %s', i, var_input1),
 			sprintf('PULLDOWN_COMPARE_%s_INPUT2 := %s', i, var_input2),
 			sprintf('PULLDOWN_COMPARE_%s_CHIP1 := %s', i, var_chip1),
@@ -116,11 +116,11 @@ if(bool_pull_comp) {
 			sprintf('.PHONY : pulldown_compare_%s', i),
 			sprintf('pulldown_compare_%s : $(PULLDOWN_COMPARE_%s_PREREQS)', i, i),
 			'',
-			sprintf('%s : %s %s %s %s', up_bed, var_input1_pre, var_input2_pre, var_chip1_pre, var_chip2_pre),
+			sprintf('%s : %s %s %s %s', chip1_bed, var_input1_pre, var_input2_pre, var_chip1_pre, var_chip2_pre),
 			sprintf('	$(PATH_TO_PEPR) --input1=$(PULLDOWN_COMPARE_%s_INPUT1) --input2=$(PULLDOWN_COMPARE_%s_INPUT2) --chip1=$(PULLDOWN_COMPARE_%s_CHIP1) --chip2=$(PULLDOWN_COMPARE_%s_CHIP2) --name=$(PULLDOWN_COMPARE_%s_NAME) --output-directory=$(DIR_PULL_PEPR) $(OPTS_PEPR_%s)', i, i, i, i, i, var_name),
-			sprintf('%s : %s', down_bed, up_bed),
+			sprintf('%s : %s', chip2_bed, chip1_bed),
 			'',
-			sprintf('%s : %s %s', combined_bed, up_bed, down_bed),
+			sprintf('%s : %s %s', combined_bed, chip1_bed, chip2_bed),
 			'	bash ../../scripts/pepr_combine.sh $(word 1,$^) $(word 2,$^) $@',
 			'',
 			sprintf('.INTERMEDIATE : %s', annotatr_bed),

--- a/scripts/sub_init_pull_compare.R
+++ b/scripts/sub_init_pull_compare.R
@@ -109,7 +109,7 @@ if(bool_pull_comp) {
 			sprintf('PULLDOWN_COMPARE_%s_CHIP1 := %s', i, var_chip1),
 			sprintf('PULLDOWN_COMPARE_%s_CHIP2 := %s', i, var_chip2),
 			sprintf('PULLDOWN_COMPARE_%s_NAME := %s', i, var_name),
-			sprintf('PULLDOWN_COMPARE_%s_CLEAN_TMP := %s', annotatr_bed))
+			sprintf('PULLDOWN_COMPARE_%s_CLEAN_TMP := %s', i, annotatr_bed))
 		cat(make_var_pull_compare, file = file_make, sep='\n', append=T)
 
 		# Write the pulldown_compare rule for this comparison

--- a/scripts/sub_init_pull_sample.R
+++ b/scripts/sub_init_pull_sample.R
@@ -10,7 +10,7 @@ PULLDOWN_SAMPLE_PREFIXES := %s', paste(pulldown_samples_noinput$fullHumanID, col
 
 
 make_var_pull_samp = 'PULLDOWN_SAMPLE_PREREQS :=	$(patsubst %,$(DIR_TRACK)/%_simple_classification.bb,$(PULLDOWN_SAMPLE_PREFIXES)) \\
-						$(patsubst %,$(DIR_SUM_FIGURES)/%_simple_class_counts.png,$(PULLDOWN_SAMPLE_PREFIXES)) \\
+						$(patsubst %,$(DIR_RDATA)/%_simple_class_annotatr_analysis.RData,$(PULLDOWN_SAMPLE_PREFIXES)) \\
 						$(patsubst %,$(DIR_CLASS_SIMPLE)/%_simple_classification.bed,$(PULLDOWN_SAMPLE_PREFIXES)) \\
 						$(patsubst %,$(DIR_TRACK)/%_macs2_peaks.bb,$(PULLDOWN_SAMPLE_PREFIXES)) \\
 						$(patsubst %,$(DIR_PULL_MACS)/%_macs2_peaks.narrowPeak,$(PULLDOWN_SAMPLE_PREFIXES))'
@@ -29,7 +29,7 @@ $(DIR_TRACK)/%_pulldown_simple_classification.bb : $(DIR_CLASS_SIMPLE)/%_pulldow
 	$(PATH_TO_BDG2BB) $< $(CHROM_PATH) $@
 
 # Rule for annotatr of simple classification
-$(DIR_SUM_FIGURES)/%_pulldown_simple_class_counts.png : $(DIR_CLASS_SIMPLE)/%_pulldown_simple_class_for_annotatr.txt
+$(DIR_RDATA)/%_simple_class_annotatr_analysis.RData : $(DIR_CLASS_SIMPLE)/%_pulldown_simple_class_for_annotatr.txt
 	$(PATH_TO_R) ../../scripts/annotatr_classification.R --file $< --genome $(GENOME)
 
 .INTERMEDIATE : $(DIR_CLASS_SIMPLE)/%_pulldown_simple_class_for_annotatr.txt

--- a/scripts/sub_init_pull_sample.R
+++ b/scripts/sub_init_pull_sample.R
@@ -29,7 +29,7 @@ $(DIR_TRACK)/%_pulldown_simple_classification.bb : $(DIR_CLASS_SIMPLE)/%_pulldow
 	$(PATH_TO_BDG2BB) $< $(CHROM_PATH) $@
 
 # Rule for annotatr of simple classification
-$(DIR_RDATA)/%_simple_class_annotatr_analysis.RData : $(DIR_CLASS_SIMPLE)/%_pulldown_simple_class_for_annotatr.txt
+$(DIR_RDATA)/%_pulldown_simple_class_annotatr_analysis.RData : $(DIR_CLASS_SIMPLE)/%_pulldown_simple_class_for_annotatr.txt
 	$(PATH_TO_R) ../../scripts/annotatr_classification.R --file $< --genome $(GENOME)
 
 .INTERMEDIATE : $(DIR_CLASS_SIMPLE)/%_pulldown_simple_class_for_annotatr.txt

--- a/scripts/sub_init_pull_sample.R
+++ b/scripts/sub_init_pull_sample.R
@@ -67,22 +67,22 @@ cat(make_rule_pull_samp, file = file_make, sep = '\n', append = TRUE)
 
 #######################################
 # PBS script
-# pulldown_sample_q = c(
-# 	'#!/bin/bash',
-# 	'#### Begin PBS preamble',
-# 	'#PBS -N pull_sample',
-# 	'#PBS -l procs=4,mem=32gb,walltime=6:00:00',
-# 	'#PBS -A sartor_lab',
-# 	'#PBS -q first',
-# 	'#PBS -M rcavalca@umich.edu',
-# 	'#PBS -m abe',
-# 	'#PBS -j oe',
-# 	'#PBS -V',
-# 	'#### End PBS preamble',
-# 	'# Put your job commands after this line',
-# 	sprintf('cd ~/latte/mint/projects/%s/',project),
-# 	'make -j 4 pulldown_sample')
-# cat(pulldown_sample_q, file=sprintf('projects/%s/pbs_jobs/pulldown_sample.q', project), sep='\n')
+pulldown_sample_q = c(
+	'#!/bin/bash',
+	'#### Begin PBS preamble',
+	'#PBS -N pull_sample',
+	'#PBS -l nodes=1:ppn=6,walltime=24:00:00,pmem=8gb',
+	'#PBS -A sartor_lab',
+	'#PBS -q first',
+	'#PBS -M rcavalca@umich.edu',
+	'#PBS -m abe',
+	'#PBS -j oe',
+	'#PBS -V',
+	'#### End PBS preamble',
+	'# Put your job commands after this line',
+	sprintf('cd ~/latte/mint/projects/%s/',project),
+	'make -j 6 pulldown_sample')
+cat(pulldown_sample_q, file=sprintf('projects/%s/pbs_jobs/pulldown_sample.q', project), sep='\n')
 
 for(i in 1:nrow(pulldown_samples_noinput)) {
 	# trackDb.txt entry for MACS2 output

--- a/scripts/sub_init_pull_sample.R
+++ b/scripts/sub_init_pull_sample.R
@@ -54,7 +54,7 @@ $(DIR_PULL_MACS)/%_macs2_peaks_tmp.narrowPeak : $(DIR_PULL_MACS)/%_macs2_peaks.n
 # Rule for macs2 model
 $(DIR_PULL_MACS)/%_pulldown_macs2_model.pdf : $(DIR_PULL_MACS)/%_pulldown_macs2_model.r
 	cd $(DIR_PULL_MACS); \\
-	Rscript $<
+	Rscript $(<F)
 
 # Rule for macs2 peaks
 $(DIR_PULL_MACS)/%_pulldown_macs2_peaks.narrowPeak $(DIR_PULL_MACS)/%_pulldown_macs2_model.r : 	$(DIR_PULL_BOWTIE2)/%_pulldown_trimmed.fq.gz_aligned.bam \\

--- a/scripts/sub_init_pull_sample.R
+++ b/scripts/sub_init_pull_sample.R
@@ -15,6 +15,10 @@ make_var_pull_samp = 'PULLDOWN_SAMPLE_PREREQS :=	$(patsubst %,$(DIR_TRACK)/%_sim
 						$(patsubst %,$(DIR_TRACK)/%_macs2_peaks.bb,$(PULLDOWN_SAMPLE_PREFIXES)) \\
 						$(patsubst %,$(DIR_PULL_MACS)/%_macs2_peaks.narrowPeak,$(PULLDOWN_SAMPLE_PREFIXES))'
 
+make_var_pull_samp_clean_tmp = 'PULLDOWN_SAMPLE_CLEAN_TMP := $(patsubst %,$(DIR_CLASS_SIMPLE)/%_pulldown_simple_class_for_annotatr.txt,$(PULLDOWN_SAMPLE_PREFIXES)) \\
+						$(patsubst %,$(DIR_PULL_MACS)/%_macs2_peaks_tmp.narrowPeak,$(PULLDOWN_SAMPLE_PREFIXES))
+'
+
 # NOTE: This cannot be indented because they would mess up the makefile
 make_rule_pull_samp = '
 .PHONY : pulldown_sample
@@ -49,10 +53,16 @@ $(DIR_PULL_MACS)/%_macs2_peaks_tmp.narrowPeak : $(DIR_PULL_MACS)/%_macs2_peaks.n
 $(DIR_PULL_MACS)/%_pulldown_macs2_peaks.narrowPeak : 	$(DIR_PULL_BOWTIE2)/%_pulldown_trimmed.fq.gz_aligned.bam \\
 														$(DIR_PULL_BOWTIE2)/%_input_pulldown_trimmed.fq.gz_aligned.bam
 	$(PATH_TO_MACS) callpeak -t $(word 1, $^) -c $(word 2, $^) -f BAM -g hs --name $(patsubst %_peaks.narrowPeak,%,$(@F)) --outdir $(@D)
+
+# Rule to delete all temporary files from make bis_align
+.PHONY : clean_pulldown_sample_tmp
+clean_pulldown_sample_tmp :
+	rm -f $(PULLDOWN_SAMPLE_CLEAN_TMP)
 '
 
 cat(make_var_pull_samp_prefix, file = file_make, sep = '\n', append = TRUE)
 cat(make_var_pull_samp, file = file_make, sep = '\n', append = TRUE)
+cat(make_var_pull_samp_clean_tmp, file = file_make, sep = '\n', append = TRUE)
 cat(make_rule_pull_samp, file = file_make, sep = '\n', append = TRUE)
 
 #######################################

--- a/scripts/sub_init_pull_sample.R
+++ b/scripts/sub_init_pull_sample.R
@@ -13,7 +13,9 @@ make_var_pull_samp = 'PULLDOWN_SAMPLE_PREREQS :=	$(patsubst %,$(DIR_TRACK)/%_sim
 						$(patsubst %,$(DIR_RDATA)/%_simple_class_annotatr_analysis.RData,$(PULLDOWN_SAMPLE_PREFIXES)) \\
 						$(patsubst %,$(DIR_CLASS_SIMPLE)/%_simple_classification.bed,$(PULLDOWN_SAMPLE_PREFIXES)) \\
 						$(patsubst %,$(DIR_TRACK)/%_macs2_peaks.bb,$(PULLDOWN_SAMPLE_PREFIXES)) \\
-						$(patsubst %,$(DIR_PULL_MACS)/%_macs2_peaks.narrowPeak,$(PULLDOWN_SAMPLE_PREFIXES))'
+						$(patsubst %,$(DIR_PULL_MACS)/%_macs2_peaks.narrowPeak,$(PULLDOWN_SAMPLE_PREFIXES)) \\
+						$(patsubst %,$(DIR_PULL_MACS)/%_macs2_model.r,$(PULLDOWN_SAMPLE_PREFIXES)) \\
+						$(patsubst %,$(DIR_PULL_MACS)/%_macs2_model.pdf,$(PULLDOWN_SAMPLE_PREFIXES))'
 
 make_var_pull_samp_clean_tmp = 'PULLDOWN_SAMPLE_CLEAN_TMP := $(patsubst %,$(DIR_CLASS_SIMPLE)/%_pulldown_simple_class_for_annotatr.txt,$(PULLDOWN_SAMPLE_PREFIXES)) \\
 						$(patsubst %,$(DIR_PULL_MACS)/%_macs2_peaks_tmp.narrowPeak,$(PULLDOWN_SAMPLE_PREFIXES))
@@ -49,8 +51,13 @@ $(DIR_TRACK)/%_macs2_peaks.bb : $(DIR_PULL_MACS)/%_macs2_peaks_tmp.narrowPeak
 $(DIR_PULL_MACS)/%_macs2_peaks_tmp.narrowPeak : $(DIR_PULL_MACS)/%_macs2_peaks.narrowPeak
 	$(PATH_TO_AWK) -f ../../scripts/macs_fix_narrowPeak.awk $^ | sort -T . -k1,1 -k2,2n > $@
 
+# Rule for macs2 model
+$(DIR_PULL_MACS)/%_pulldown_macs2_model.pdf : $(DIR_PULL_MACS)/%_pulldown_macs2_model.r
+	cd $(DIR_PULL_MACS); \\
+	Rscript $<
+
 # Rule for macs2 peaks
-$(DIR_PULL_MACS)/%_pulldown_macs2_peaks.narrowPeak : 	$(DIR_PULL_BOWTIE2)/%_pulldown_trimmed.fq.gz_aligned.bam \\
+$(DIR_PULL_MACS)/%_pulldown_macs2_peaks.narrowPeak $(DIR_PULL_MACS)/%_pulldown_macs2_model.r : 	$(DIR_PULL_BOWTIE2)/%_pulldown_trimmed.fq.gz_aligned.bam \\
 														$(DIR_PULL_BOWTIE2)/%_input_pulldown_trimmed.fq.gz_aligned.bam
 	$(PATH_TO_MACS) callpeak -t $(word 1, $^) -c $(word 2, $^) -f BAM -g hs --name $(patsubst %_peaks.narrowPeak,%,$(@F)) --outdir $(@D)
 

--- a/scripts/sub_init_sample_class.R
+++ b/scripts/sub_init_sample_class.R
@@ -120,7 +120,7 @@ make_rule_class_sample = sprintf('
 # Master rule
 .PHONY : sample_classification
 sample_classification : 	$(patsubst %%,$(DIR_TRACK)/%%_sample_classification.bb,$(SAMPLE_CLASS_PREFIXES)) \\
-		$(patsubst %%,$(DIR_SUM_FIGURES)/%%_sample_class_counts.png,$(SAMPLE_CLASS_PREFIXES)) \\
+		$(patsubst %%,$(DIR_RDATA)/%%_sample_class_annotatr_analysis.RData,$(SAMPLE_CLASS_PREFIXES)) \\
 		$(patsubst %%,$(DIR_CLASS_SAMPLE)/%%_sample_classification.bed,$(SAMPLE_CLASS_PREFIXES))
 
 # Rule for sample classification bigBed
@@ -128,7 +128,7 @@ $(DIR_TRACK)/%%_sample_classification.bb : $(DIR_CLASS_SAMPLE)/%%_sample_classif
 	$(PATH_TO_BDG2BB) $^ $(CHROM_PATH) $@
 
 # Rule for annotatr of sample classification
-$(DIR_SUM_FIGURES)/%%_sample_class_counts.png : $(DIR_CLASS_SAMPLE)/%%_sample_class_for_annotatr.txt
+$(DIR_RDATA)/%%_sample_class_annotatr_analysis.RData : $(DIR_CLASS_SAMPLE)/%%_sample_class_for_annotatr.txt
 	$(PATH_TO_R) ../../scripts/annotatr_classification.R --file $< --genome $(GENOME)
 
 .INTERMEDIATE : $(DIR_CLASS_SAMPLE)/%%_sample_class_for_annotatr.txt

--- a/scripts/sub_init_sample_class.R
+++ b/scripts/sub_init_sample_class.R
@@ -119,8 +119,7 @@ if(bool_bis_samp && bool_pull_samp) {
 make_rule_class_sample = sprintf('
 # Master rule
 .PHONY : sample_classification
-sample_classification : 	pulldown_align pulldown_sample bisulfite_align \\
-		$(patsubst %%,$(DIR_TRACK)/%%_sample_classification.bb,$(SAMPLE_CLASS_PREFIXES)) \\
+sample_classification : 	$(patsubst %%,$(DIR_TRACK)/%%_sample_classification.bb,$(SAMPLE_CLASS_PREFIXES)) \\
 		$(patsubst %%,$(DIR_SUM_FIGURES)/%%_sample_class_counts.png,$(SAMPLE_CLASS_PREFIXES)) \\
 		$(patsubst %%,$(DIR_CLASS_SAMPLE)/%%_sample_classification.bed,$(SAMPLE_CLASS_PREFIXES))
 

--- a/scripts/sub_init_sample_class.R
+++ b/scripts/sub_init_sample_class.R
@@ -119,7 +119,8 @@ if(bool_bis_samp && bool_pull_samp) {
 make_rule_class_sample = sprintf('
 # Master rule
 .PHONY : sample_classification
-sample_classification : 	$(patsubst %%,$(DIR_TRACK)/%%_sample_classification.bb,$(SAMPLE_CLASS_PREFIXES)) \\
+sample_classification : 	pulldown_align pulldown_sample bisulfite_align \\
+		$(patsubst %%,$(DIR_TRACK)/%%_sample_classification.bb,$(SAMPLE_CLASS_PREFIXES)) \\
 		$(patsubst %%,$(DIR_SUM_FIGURES)/%%_sample_class_counts.png,$(SAMPLE_CLASS_PREFIXES)) \\
 		$(patsubst %%,$(DIR_CLASS_SAMPLE)/%%_sample_classification.bed,$(SAMPLE_CLASS_PREFIXES))
 

--- a/scripts/sub_init_sample_class.R
+++ b/scripts/sub_init_sample_class.R
@@ -40,7 +40,7 @@ $(DIR_PULL_MACS)/%_pulldown_nopeak.txt : $(DIR_PULL_MACS)/%_pulldown_peak.txt
 	> $@
 
 .INTERMEDIATE : $(DIR_PULL_MACS)/%_pulldown_signal.txt
-$(DIR_PULL_MACS)/%_pulldown_signal.txt : $(DIR_PULL_COVERAGES)/%_input_pulldown_merged_coverage.bdg
+$(DIR_PULL_MACS)/%_pulldown_signal.txt : $(DIR_PULL_COVERAGES)/%_input_pulldown_coverage_merged.bdg
 	cp $< $@
 
 .INTERMEDIATE : $(DIR_PULL_MACS)/%_pulldown_nosignal.txt

--- a/scripts/sub_init_sample_class.R
+++ b/scripts/sub_init_sample_class.R
@@ -145,8 +145,8 @@ $(DIR_CLASS_SAMPLE)/%%_sample_class_for_annotatr.txt : $(DIR_CLASS_SAMPLE)/%%_sa
 # Clean temporary files that make does not clean up
 %s
 
-.PHONY : sample_classification_clean_tmp
-sample_classification_clean_tmp :
+.PHONY : clean_sample_classification_tmp
+clean_sample_classification_tmp :
 	rm -f $(SAMPLE_CLASS_CLEAN_TMP)',
 	sample_class_target, class_script, rule1, rule2, sample_class_tmps)
 cat(make_rule_class_sample, file = file_make, sep = '\n', append = TRUE)

--- a/scripts/sub_init_sample_class.R
+++ b/scripts/sub_init_sample_class.R
@@ -10,7 +10,7 @@ $(DIR_BIS_BISMARK)/%_bisulfite_trimmed_bismark_bt2.CpG_report.txt : $(DIR_BIS_BI
 
 # Intermediates for the bisulfite piece
 $(DIR_BIS_BISMARK)/%_bisulfite_highmeth.txt $(DIR_BIS_BISMARK)/%_bisulfite_lowmeth.txt $(DIR_BIS_BISMARK)/%_bisulfite_nometh_signal.txt $(DIR_BIS_BISMARK)/%_bisulfite_nometh_nosignal.txt : $(DIR_BIS_BISMARK)/%_bisulfite_trimmed_bismark_bt2.CpG_report.txt
-	$(PATH_TO_AWK) -f ../../scripts/classify_prepare_bisulfite_sample.awk $<
+	$(PATH_TO_AWK) -v MIN_COV=$(OPT_MIN_COV) -f ../../scripts/classify_prepare_bisulfite_sample.awk $<
 '
 
 make_rule_sample_class_pull_module = '

--- a/scripts/sub_init_sample_class.R
+++ b/scripts/sub_init_sample_class.R
@@ -58,7 +58,13 @@ cat(make_var_sample_class_prefix, file = file_make, sep = '\n', append = TRUE)
 
 # The sample class type depends on the type of samples present
 if(bool_bis_samp && bool_pull_samp) {
-	extra_removes = 'rm -f $(DIR_BIS_BISMARK)/$*_mc_hmc_bisulfite_lowmeth.txt $(DIR_BIS_BISMARK)/$*_mc_hmc_bisulfite_nometh_signal.txt $(DIR_BIS_BISMARK)/$*_mc_hmc_bisulfite_nometh_nosignal.txt $(DIR_PULL_MACS)/$*_hmc_pulldown_peak.txt'
+	sample_class_tmps = '$(SAMPLE_CLASS_CLEAN_TMP) := $(patsubst %,$(DIR_BIS_BISMARK)/%_mc_hmc_bisulfite_highmeth.txt,$(SAMPLE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_BIS_BISMARK)/%_mc_hmc_bisulfite_lowmeth.txt,$(SAMPLE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_BIS_BISMARK)/%_mc_hmc_bisulfite_nometh_signal.txt,$(SAMPLE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_BIS_BISMARK)/%_mc_hmc_bisulfite_nometh_nosignal.txt,$(SAMPLE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_PULL_MACS)/%_hmc_pulldown_peak.txt,$(SAMPLE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_PULL_MACS)/%_hmc_pulldown_nopeak_signal.txt,$(SAMPLE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_PULL_MACS)/%_hmc_pulldown_nopeak_nosignal.txt,$(SAMPLE_CLASS_PREFIXES))'
 	sample_class_target = '$(DIR_CLASS_SAMPLE)/%_sample_classification.bed : 	$(DIR_BIS_BISMARK)/%_mc_hmc_bisulfite_highmeth.txt \\
 								$(DIR_BIS_BISMARK)/%_mc_hmc_bisulfite_lowmeth.txt \\
 								$(DIR_BIS_BISMARK)/%_mc_hmc_bisulfite_nometh_signal.txt \\
@@ -73,7 +79,14 @@ if(bool_bis_samp && bool_pull_samp) {
 	############################################################
 	# NOTE: THIS IS NOT EXPLICITLY SUPPORTED RIGHT NOW
 	############################################################
-	extra_removes = 'rm -f $(DIR_BIS_BISMARK)/$*_mc_bisulfite_lowmeth.txt $(DIR_BIS_BISMARK)/$*_mc_bisulfite_nometh_signal.txt $(DIR_BIS_BISMARK)/$*_mc_bisulfite_nometh_nosignal.txt $(DIR_BIS_BISMARK)/$*_hmc_bisulfite_lowmeth.txt $(DIR_BIS_BISMARK)/$*_hmc_bisulfite_nometh_signal.txt $(DIR_BIS_BISMARK)/$*_hmc_bisulfite_nometh_nosignal.txt'
+	sample_class_tmps = '$(SAMPLE_CLASS_CLEAN_TMP) := $(patsubst %,$(DIR_BIS_BISMARK)/%_mc_bisulfite_highmeth.txt,$(SAMPLE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_BIS_BISMARK)/%_mc_bisulfite_lowmeth.txt,$(SAMPLE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_BIS_BISMARK)/%_mc_bisulfite_nometh_signal.txt,$(SAMPLE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_BIS_BISMARK)/%_mc_bisulfite_nometh_nosignal.txt,$(SAMPLE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_BIS_BISMARK)/%_hmc_bisulfite_highmeth.txt,$(SAMPLE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_BIS_BISMARK)/%_hmc_bisulfite_lowmeth.txt,$(SAMPLE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_BIS_BISMARK)/%_hmc_bisulfite_nometh_signal.txt,$(SAMPLE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_BIS_BISMARK)/%_hmc_bisulfite_nometh_nosignal.txt,$(SAMPLE_CLASS_PREFIXES))'
 	sample_class_target = '$(DIR_CLASS_SAMPLE)/%_sample_classification.bed : 	$(DIR_BIS_BISMARK)/%_mc_bisulfite_highmeth.txt \\
 								$(DIR_BIS_BISMARK)/%_mc_bisulfite_lowmeth.txt \\
 								$(DIR_BIS_BISMARK)/%_mc_bisulfite_nometh_signal.txt \\
@@ -86,7 +99,12 @@ if(bool_bis_samp && bool_pull_samp) {
 	rule2 = ''
 	class_script = '../../scripts/classify_bisulfite_sample.sh'
 } else {
-	extra_removes = 'rm -f $(DIR_PULL_MACS)/$*_mc_pulldown_peak.txt $(DIR_PULL_MACS)/$*_hmc_pulldown_peak.txt'
+	sample_class_tmps = '$(SAMPLE_CLASS_CLEAN_TMP) := $(patsubst %,$(DIR_PULL_MACS)/%_mc_pulldown_peak.txt,$(SAMPLE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_PULL_MACS)/%_mc_pulldown_nopeak_signal.txt,$(SAMPLE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_PULL_MACS)/%_mc_pulldown_nopeak_nosignal.txt,$(SAMPLE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_PULL_MACS)/%_hmc_pulldown_peak.txt,$(SAMPLE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_PULL_MACS)/%_hmc_pulldown_nopeak_signal.txt,$(SAMPLE_CLASS_PREFIXES)) \\
+								$(patsubst %,$(DIR_PULL_MACS)/%_hmc_pulldown_nopeak_nosignal.txt,$(SAMPLE_CLASS_PREFIXES))'
 	sample_class_target = '$(DIR_CLASS_SAMPLE)/%_sample_classification.bed : 	$(DIR_PULL_MACS)/%_mc_pulldown_peak.txt \\
 								$(DIR_PULL_MACS)/%_mc_pulldown_nopeak_signal.txt \\
 								$(DIR_PULL_MACS)/%_mc_pulldown_nopeak_nosignal.txt \\
@@ -117,18 +135,20 @@ $(DIR_SUM_FIGURES)/%%_sample_class_counts.png : $(DIR_CLASS_SAMPLE)/%%_sample_cl
 $(DIR_CLASS_SAMPLE)/%%_sample_class_for_annotatr.txt : $(DIR_CLASS_SAMPLE)/%%_sample_classification.bed
 	cut -f 1-4 $< > $@
 
-# NOTE: There is a known bug in make that incorrectly determines implicit intermediate
-# files when they occur in a list of multiple targets and prerequisites.
-# https://savannah.gnu.org/bugs/index.php?32042
-# The easiest workaround is to remove the ones make does not automatically remove
-
 # Classification BED
 %s
 	bash %s $(PATH_TO_BEDTOOLS) $(PATH_TO_AWK) $(CHROM_PATH) $@ $^
 
 %s
-%s',
-	sample_class_target, class_script, rule1, rule2)
+%s
+
+# Clean temporary files that make does not clean up
+%s
+
+.PHONY : sample_classification_clean_tmp
+sample_classification_clean_tmp :
+	rm -f $(SAMPLE_CLASS_CLEAN_TMP)',
+	sample_class_target, class_script, rule1, rule2, sample_class_tmps)
 cat(make_rule_class_sample, file = file_make, sep = '\n', append = TRUE)
 
 #######################################

--- a/scripts/sub_init_sample_class.R
+++ b/scripts/sub_init_sample_class.R
@@ -153,22 +153,22 @@ cat(make_rule_class_sample, file = file_make, sep = '\n', append = TRUE)
 
 #######################################
 # PBS script
-# pulldown_sample_q = c(
-# 	'#!/bin/bash',
-# 	'#### Begin PBS preamble',
-# 	'#PBS -N class_sample',
-# 	'#PBS -l procs=4,mem=48gb,walltime=6:00:00',
-# 	'#PBS -A sartor_lab',
-# 	'#PBS -q first',
-# 	'#PBS -M rcavalca@umich.edu',
-# 	'#PBS -m abe',
-# 	'#PBS -j oe',
-# 	'#PBS -V',
-# 	'#### End PBS preamble',
-# 	'# Put your job commands after this line',
-# 	sprintf('cd ~/latte/mint/projects/%s/',project),
-# 	'make -j 4 sample_classification')
-# cat(pulldown_sample_q, file=sprintf('projects/%s/pbs_jobs/classify_sample.q', project), sep='\n')
+pulldown_sample_q = c(
+	'#!/bin/bash',
+	'#### Begin PBS preamble',
+	'#PBS -N class_sample',
+	'#PBS -l nodes=1:ppn=4,walltime=24:00:00,pmem=16gb',
+	'#PBS -A sartor_lab',
+	'#PBS -q first',
+	'#PBS -M rcavalca@umich.edu',
+	'#PBS -m abe',
+	'#PBS -j oe',
+	'#PBS -V',
+	'#### End PBS preamble',
+	'# Put your job commands after this line',
+	sprintf('cd ~/latte/mint/projects/%s/',project),
+	'make -j 4 sample_classification')
+cat(pulldown_sample_q, file=sprintf('projects/%s/pbs_jobs/classify_sample.q', project), sep='\n')
 
 for(sample in unique(samples$humanID)) {
 	# trackDb.txt entry for sample classification

--- a/scripts/sub_init_sample_class.R
+++ b/scripts/sub_init_sample_class.R
@@ -58,7 +58,7 @@ cat(make_var_sample_class_prefix, file = file_make, sep = '\n', append = TRUE)
 
 # The sample class type depends on the type of samples present
 if(bool_bis_samp && bool_pull_samp) {
-	sample_class_tmps = '$(SAMPLE_CLASS_CLEAN_TMP) := $(patsubst %,$(DIR_BIS_BISMARK)/%_mc_hmc_bisulfite_highmeth.txt,$(SAMPLE_CLASS_PREFIXES)) \\
+	sample_class_tmps = 'SAMPLE_CLASS_CLEAN_TMP := $(patsubst %,$(DIR_BIS_BISMARK)/%_mc_hmc_bisulfite_highmeth.txt,$(SAMPLE_CLASS_PREFIXES)) \\
 								$(patsubst %,$(DIR_BIS_BISMARK)/%_mc_hmc_bisulfite_lowmeth.txt,$(SAMPLE_CLASS_PREFIXES)) \\
 								$(patsubst %,$(DIR_BIS_BISMARK)/%_mc_hmc_bisulfite_nometh_signal.txt,$(SAMPLE_CLASS_PREFIXES)) \\
 								$(patsubst %,$(DIR_BIS_BISMARK)/%_mc_hmc_bisulfite_nometh_nosignal.txt,$(SAMPLE_CLASS_PREFIXES)) \\
@@ -79,7 +79,7 @@ if(bool_bis_samp && bool_pull_samp) {
 	############################################################
 	# NOTE: THIS IS NOT EXPLICITLY SUPPORTED RIGHT NOW
 	############################################################
-	sample_class_tmps = '$(SAMPLE_CLASS_CLEAN_TMP) := $(patsubst %,$(DIR_BIS_BISMARK)/%_mc_bisulfite_highmeth.txt,$(SAMPLE_CLASS_PREFIXES)) \\
+	sample_class_tmps = 'SAMPLE_CLASS_CLEAN_TMP := $(patsubst %,$(DIR_BIS_BISMARK)/%_mc_bisulfite_highmeth.txt,$(SAMPLE_CLASS_PREFIXES)) \\
 								$(patsubst %,$(DIR_BIS_BISMARK)/%_mc_bisulfite_lowmeth.txt,$(SAMPLE_CLASS_PREFIXES)) \\
 								$(patsubst %,$(DIR_BIS_BISMARK)/%_mc_bisulfite_nometh_signal.txt,$(SAMPLE_CLASS_PREFIXES)) \\
 								$(patsubst %,$(DIR_BIS_BISMARK)/%_mc_bisulfite_nometh_nosignal.txt,$(SAMPLE_CLASS_PREFIXES)) \\
@@ -99,7 +99,7 @@ if(bool_bis_samp && bool_pull_samp) {
 	rule2 = ''
 	class_script = '../../scripts/classify_bisulfite_sample.sh'
 } else {
-	sample_class_tmps = '$(SAMPLE_CLASS_CLEAN_TMP) := $(patsubst %,$(DIR_PULL_MACS)/%_mc_pulldown_peak.txt,$(SAMPLE_CLASS_PREFIXES)) \\
+	sample_class_tmps = 'SAMPLE_CLASS_CLEAN_TMP := $(patsubst %,$(DIR_PULL_MACS)/%_mc_pulldown_peak.txt,$(SAMPLE_CLASS_PREFIXES)) \\
 								$(patsubst %,$(DIR_PULL_MACS)/%_mc_pulldown_nopeak_signal.txt,$(SAMPLE_CLASS_PREFIXES)) \\
 								$(patsubst %,$(DIR_PULL_MACS)/%_mc_pulldown_nopeak_nosignal.txt,$(SAMPLE_CLASS_PREFIXES)) \\
 								$(patsubst %,$(DIR_PULL_MACS)/%_hmc_pulldown_peak.txt,$(SAMPLE_CLASS_PREFIXES)) \\

--- a/scripts/sub_init_setup.R
+++ b/scripts/sub_init_setup.R
@@ -24,7 +24,8 @@ setup_commands = c(
 	sprintf('mkdir projects/%s/%s_hub', project, project),
 	sprintf('mkdir projects/%s/%s_hub/%s', project, project, genome),
 	sprintf('mkdir projects/%s/classifications', project),
-	sprintf('mkdir projects/%s/classifications/{simple,sample}', project)
+	sprintf('mkdir projects/%s/classifications/{simple,sample}', project),
+	sprintf('mkdir projects/%s/RData', project)
 )
 
 # Create folders for bisulfite samples if there are any

--- a/template_config.mk
+++ b/template_config.mk
@@ -33,13 +33,13 @@ PATH_TO_BDG2BB := $(shell which bedToBigBed)
 # FastQC
 OPTS_FASTQC = --format fastq --noextract
 # trim_galore bisulfite
-OPTS_TRIMGALORE_BISULFITE = --quality 20 --illumina --stringency 6 -e 0.2 --gzip --length 20 --rrbs
+OPTS_TRIMGALORE_BISULFITE = --quality 20 --illumina --stringency 6 -e 0.2 --gzip --length 25 --rrbs
 # trim_galore pulldown
-OPTS_TRIMGALORE_PULLDOWN = --quality 20 --illumina --stringency 6 -e 0.2 --gzip --length 20
+OPTS_TRIMGALORE_PULLDOWN = --quality 20 --illumina --stringency 6 -e 0.2 --gzip --length 25
 # bismark
 OPTS_BISMARK = --bowtie2 $(GENOME_PATH)
 # bismark_methylation_extractor
-OPTS_EXTRACTOR = --single-end --gzip --bedGraph --cutoff 5 --cytosine_report --genome_folder $(GENOME_PATH) --multicore 5
+OPTS_EXTRACTOR = --single-end --gzip --bedGraph --cutoff 5 --cytosine_report --genome_folder $(GENOME_PATH) --multicore 1
 # bowtie2
 OPTS_BOWTIE2 = -q -x $(BOWTIE2_GENOME_PATH) -U
 # macs2
@@ -53,8 +53,8 @@ OPTS_MACS = -t $bowtie2Bam -c $bowtie2InputBam -f BAM -g hs --outdir ./analysis/
 OPT_DM_TYPE = DMR
 
 # Thresholds to use for DMCs or DMRs (above) in methylSig
-OPT_MSIG_DM_FDR_THRESHOLD = 0.2
-OPT_MSIG_DM_DIFF_THRESHOLD = 5
+OPT_MSIG_DM_FDR_THRESHOLD = 0.05
+OPT_MSIG_DM_DIFF_THRESHOLD = 10
 
 ################################################################################
 # Comparison specific options

--- a/template_config.mk
+++ b/template_config.mk
@@ -28,22 +28,11 @@ PATH_TO_BDG2BW := $(shell which bedGraphToBigWig)
 PATH_TO_BDG2BB := $(shell which bedToBigBed)
 
 ################################################################################
-# Command line options for tools
-
-# FastQC
-OPTS_FASTQC = --format fastq --noextract
-# trim_galore bisulfite
-OPTS_TRIMGALORE_BISULFITE = --quality 20 --illumina --stringency 6 -e 0.2 --gzip --length 25 --rrbs
-# trim_galore pulldown
-OPTS_TRIMGALORE_PULLDOWN = --quality 20 --illumina --stringency 6 -e 0.2 --gzip --length 25
-# bismark
-OPTS_BISMARK = --bowtie2 $(GENOME_PATH)
-# bismark_methylation_extractor
-OPTS_EXTRACTOR = --single-end --gzip --bedGraph --cutoff 5 --cytosine_report --genome_folder $(GENOME_PATH) --multicore 1
-# bowtie2
-OPTS_BOWTIE2 = -q -x $(BOWTIE2_GENOME_PATH) -U
-# macs2
-OPTS_MACS = -t $bowtie2Bam -c $bowtie2InputBam -f BAM -g hs --outdir ./analysis/macs_peaks -n $macsPrefix
+# Command line option for minimum coverage required for
+# bismark_methylation_extractor and scripts/classify_prepare_bisulfite_sample.awk
+# in the sample classification module
+# NOTE: This is decoupled from the minCount parameter for methylSig runs
+OPT_MIN_COV = 5
 
 ################################################################################
 # Command line options for methylSig and compare classifications
@@ -55,6 +44,24 @@ OPT_DM_TYPE = DMR
 # Thresholds to use for DMCs or DMRs (above) in methylSig
 OPT_MSIG_DM_FDR_THRESHOLD = 0.05
 OPT_MSIG_DM_DIFF_THRESHOLD = 10
+
+################################################################################
+# Command line options for tools
+
+# FastQC
+OPTS_FASTQC = --format fastq --noextract
+# trim_galore bisulfite
+OPTS_TRIMGALORE_BISULFITE = --quality 20 --illumina --stringency 6 -e 0.2 --gzip --length 25 --rrbs
+# trim_galore pulldown
+OPTS_TRIMGALORE_PULLDOWN = --quality 20 --illumina --stringency 6 -e 0.2 --gzip --length 25
+# bismark
+OPTS_BISMARK = --bowtie2 $(GENOME_PATH)
+# bismark_methylation_extractor
+OPTS_EXTRACTOR = --single-end --gzip --bedGraph --cutoff $(OPT_MIN_COV) --cytosine_report --genome_folder $(GENOME_PATH) --multicore 1
+# bowtie2
+OPTS_BOWTIE2 = -q -x $(BOWTIE2_GENOME_PATH) -U
+# macs2
+OPTS_MACS = -t $bowtie2Bam -c $bowtie2InputBam -f BAM -g hs --outdir ./analysis/macs_peaks -n $macsPrefix
 
 ################################################################################
 # Comparison specific options

--- a/template_makefile
+++ b/template_makefile
@@ -1,5 +1,7 @@
 SHELL=/bin/bash
 
+# This makefile was generated using mint v0.1.0
+
 ################################################################################
 # Directories
 

--- a/template_makefile
+++ b/template_makefile
@@ -39,6 +39,9 @@ DIR_SUM_FIGURES := summary/figures
 DIR_SUM_REPORTS := summary/reports
 DIR_SUM_TABLES := summary/tables
 
+# RData directories
+DIR_RDATA := RData
+
 ################################################################################
 # Includes
 include config.mk


### PR DESCRIPTION
- An update with lots of minor tweaks.
- 705a1e9 Change PePr default threshold to 1e-05, minimum read length of 25bp for trim_galore, reduce multicore default for bismark_methylation_extractor, 0.05 FDR for methylSig significance with methylation difference of 10.
- 560e4e7 Remove coannotation plots from annotatr results. Takes too long for real data.
- eebb3f1 Write bowtie2 stderr to file to get alignment frequencies
- b83af40 Add mint version to top of makefile
- 0a7646f CpG report _for_methylSig.txt and _for_annotatr.txt are now INTERMEDIATE
- f32eb42 Save R sessions for methylSig and annotatr as .RData in /RData
- 60a90d1 Missed some PePr nomenclature changes
- A number of commits to make temporary file cleanup rule, clean_tmp
- Create _for_methylSig.txt file in the bisulfite_compare module instead of the bisulfite_align module.
- 3de4819 Change annotatr rule target from the first .png output to the .RData of the session.
- 2d0383a Add global OPT_MIN_COV variable that applies to the bismark_methylation_extractor and preparation for sample_classification.
- 84b43a5 Add region width plots for simple classification and PePr
- 9ea83b1 Add MACS2 model.pdf creation
